### PR TITLE
feat: Claude session manager & extended autonomy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ state/race_track.json
 state/race_log.jsonl
 state/race_live.json
 state/pin_lockout.json
+state/claude_sessions.jsonl
+state/debug_reports.jsonl
+state/compositions-spark.jsonl
 state/*.tmp
 state/.*.tmp
 photos/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,38 +213,71 @@ Additional: `confirm_motion_allowed` gate; `yield_alive` at startup; `exploring.
 
 Two-pass flush: Pass 1 batches all feed writes (no rate limit), Pass 2 does one Bluesky post per cycle (rate-limited). QA gate: Claude CLI answers YES/NO; "ambiguous" responses (e.g. "Maybe") default to pass — QA is a safety net for bad content, not a quality bar. PID-file single-instance guard. Branded 1080×1080 thought card images generated via Pillow (cached in `state/thought-images/`, cleaned up after 30 days). Bluesky re-auths on 400/401 (expired token). Backfill mode: `bin/px-post --backfill`. Loads `.env` via systemd `EnvironmentFile`.
 
+### Claude Session Manager (`src/pxh/claude_session.py`)
+
+Central dispatcher for all SPARK-initiated Claude Code interactions. Manages model routing, rate limiting, execution, logging, and file whitelist enforcement.
+
+**Model routing** (5 session types):
+
+| Session Type    | Model  | Cooldown | Daily Quota |
+|-----------------|--------|----------|-------------|
+| `evolve`        | Opus   | 24h      | 1/day       |
+| `self_debug`    | Sonnet | 6h       | 2/day       |
+| `research`      | Haiku  | 2h       | 3/day       |
+| `compose`       | Haiku  | 4h       | 2/day       |
+| `conversation`  | Sonnet | 15min    | 4/day       |
+
+Global: 30-min cooldown between sessions (except `self_debug`), 8/day cap. Priority gating when ≤2 remaining: only `self_debug` and `evolve` allowed. Models configurable via `PX_CLAUDE_MODEL_*` env vars.
+
+**Rate limiting**: `check_budget()` returns None (allowed) or reason string. `SessionBudgetExhausted` exception for callers. Budget bypass: `PX_CLAUDE_BUDGET_DISABLED=1`. Day boundary: midnight Hobart time.
+
+**Session log**: `state/claude_sessions.jsonl` — one JSON object per line, FileLock-protected, atomic writes.
+
 ### Self-Evolution (px-evolve)
 
 SPARK can introspect on its own thought patterns and propose targeted code changes via GitHub PR — a controlled self-modification loop with human approval required before any change takes effect.
 
 **`src/pxh/spark_config.py`** — Tunable constants extracted from `mind.py`: reflection angles (`SPARK_ANGLES`), topic seeds (`TOPIC_SEEDS`), prompts, cooldowns, salience thresholds. This is the primary safe target for self-evolution; changes here reshape SPARK's personality and curiosity without touching core logic.
 
-**`bin/tool-introspect`** — Computes thought statistics (mood distribution, action distribution, top keywords, average salience, thoughts/day), snapshots `spark_config.py` constants, and records architecture awareness. 30-min cooldown enforced via `introspection.json` timestamp. Writes `state/introspection.json`. Dry-run supported (`PX_DRY=1` sets `dry: true` in output but still writes the file).
+**`bin/tool-introspect`** — Computes thought statistics (mood distribution, action distribution, top keywords, average salience, thoughts/day), snapshots `spark_config.py` constants, and records architecture awareness. 30-min cooldown enforced via `introspection.json` timestamp. Also reports Claude session usage and evolve PR outcomes. Writes `state/introspection.json`.
 
 **`bin/tool-evolve`** — Validates introspection freshness (must be <1h old), intent quality (≥20 chars), and 24h rate limit (max 1 evolution per day). Respects `PX_DRY=1` (writes entry with `dry: true` flag; daemon marks it `skipped:dry`). Writes a `pending` entry to `state/evolve_queue.jsonl` including the full introspection snapshot. Returns `{"status": "queued", "id": "..."}`.
 
 **`bin/px-evolve` daemon** — Polls `evolve_queue.jsonl` for `pending` entries. For each:
-1. Creates a git worktree in `/tmp/px-evolve-<id>/`
-2. Runs `claude -p` with a scoped prompt (intent + introspection + file whitelist), `--allowedTools Read,Write,Edit,Bash,Glob,Grep`, and `--dangerously-skip-permissions`
-3. Runs `pytest` — marks entry `failed` and aborts on test failure
-4. Creates a PR via `gh pr create` — marks entry `pr_created` on success
-5. Cleans up worktree
+1. Creates a git worktree in `/tmp/spark-evolve-<id>/`
+2. Runs `run_claude_session(type="evolve")` with `--allowedTools Read,Write,Edit,Glob,Grep` and `--dangerously-skip-permissions` — Claude edits files directly via tools (no Bash)
+3. px-evolve stages and commits after Claude exits (`git add -A && git commit`)
+4. Validates changed files against whitelist via `git diff --name-only master...HEAD`
+5. Runs `pytest` — marks entry `failed` and aborts on test failure
+6. Creates a PR via `gh pr create --label spark-evolve` — marks entry `pr_created` on success
+7. Cleans up worktree
 
 Single-instance PID guard. Restart policy: on-failure, 30 s.
 
 **Safety constraints**:
-- **File whitelist**: `src/pxh/spark_config.py`, `bin/tool-*` (new tools only), `tests/`
-- **File blacklist**: personas, `api.py`, `mind.py`, credentials, `.env`, `px-evolve` itself
-- Max 3 files changed per evolution; 5-min Claude subprocess timeout
+- **File whitelist** (in `claude_session.py`): `src/pxh/spark_config.py`, `src/pxh/mind.py`, `src/pxh/voice_loop.py`, `bin/tool-*` (new tools only), `tests/`, `docs/prompts/`
+- **File blacklist**: `docs/prompts/persona-*`, `api.py`, `bin/tool-chat*`, `bin/px-evolve`, `.env`, `systemd/`
+- Max 3 files changed per evolution; 30-min Claude subprocess timeout (configurable)
+- Post-Claude whitelist enforcement: hard gate on changed files
 - Test gate: `pytest` must pass before PR is created
 - PR gate: human must merge — changes never auto-apply
+- Budget gate: `run_claude_session()` checks daily cap before spawning
+
+**New cognitive tools**:
+- **`bin/tool-research`** — Haiku-powered curiosity deep dives. Triggered by `research` action in mind.py expression layer. Saves to `state/notes-spark.jsonl`. Params: `query` (5-500 chars).
+- **`bin/tool-compose`** — Haiku-powered creative writing (journal, letter, observation). Triggered by `compose` action. Saves to `state/compositions-spark.jsonl`. Params: `topic` (3-500 chars).
+- **Self-debug** — Sonnet with read-only tools (`Read,Glob,Grep`), triggered by consecutive reflection failures. Saves diagnostic reports to `state/debug_reports.jsonl`. Not a separate tool — runs directly in mind.py.
+- **Conversation depth** — Voice loop detects trigger phrases ("think deeper", "go deeper", "explain that properly") and routes to Sonnet for deeper responses.
 
 **State files** (gitignored):
 - `state/introspection.json` — latest thought stats + config snapshot
 - `state/evolve_queue.jsonl` — evolution queue (status: pending/pr_created/failed:*/skipped:dry)
 - `state/evolve_log.jsonl` — per-run audit log with PR URL
+- `state/claude_sessions.jsonl` — unified Claude session log (all types)
+- `state/debug_reports.jsonl` — self-debug diagnostic reports
+- `state/compositions-spark.jsonl` — creative writing output
 
-**New env vars**: `PX_EVOLVE_DRY` (1 = skip worktree/PR), `PX_EVOLVE_MODEL` (default: `claude-opus-4-6`), `PX_EVOLVE_TIMEOUT` (default: 300 s), `PX_EVOLVE_MAX_FILES` (default: 3).
+**Env vars**: `PX_EVOLVE_DRY` (1 = skip worktree/PR), `PX_EVOLVE_MODEL` (default: `claude-opus-4-6`), `PX_EVOLVE_TIMEOUT` (default: 1800 s), `PX_EVOLVE_MAX_FILES` (default: 3), `PX_CLAUDE_DAILY_CAP` (default: 8), `PX_CLAUDE_COOLDOWN_S` (default: 1800), `PX_CLAUDE_BUDGET_DISABLED` (1 = bypass all limits), `PX_CLAUDE_MODEL_*` (per-type model overrides).
 
 ### MCP Server (Claude Code integration)
 
@@ -451,7 +484,7 @@ Every tool must: emit a single JSON object to stdout, support `PX_DRY=1`, handle
 | `PX_HA_DEBUG` | `1` = verbose HA fetch logging (per-entity, calendar, routines); errors always logged |
 | `PX_EVOLVE_DRY` | `1` = skip worktree creation and PR (queue entry still written) |
 | `PX_EVOLVE_MODEL` | Claude model for evolution proposals (default: `claude-opus-4-6`) |
-| `PX_EVOLVE_TIMEOUT` | Claude subprocess timeout in seconds (default: `300`) |
+| `PX_EVOLVE_TIMEOUT` | Claude subprocess timeout in seconds (default: `1800`) |
 | `PX_EVOLVE_MAX_FILES` | Maximum files changed per evolution (default: `3`) |
 
 ## Multi-Model QA

--- a/bin/px-evolve
+++ b/bin/px-evolve
@@ -43,8 +43,7 @@ PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", Path(__file__).parent.parent)
 LOG_DIR = Path(os.environ.get("LOG_DIR", PROJECT_ROOT / "logs"))
 STATE_DIR = Path(os.environ.get("PX_STATE_DIR", PROJECT_ROOT / "state"))
 
-EVOLVE_MODEL = os.environ.get("PX_EVOLVE_MODEL", "claude-opus-4-6")
-EVOLVE_TIMEOUT = int(os.environ.get("PX_EVOLVE_TIMEOUT", "600"))
+EVOLVE_TIMEOUT = int(os.environ.get("PX_EVOLVE_TIMEOUT", "1800"))
 EVOLVE_MAX_FILES = int(os.environ.get("PX_EVOLVE_MAX_FILES", "3"))
 POLL_INTERVAL = 60
 
@@ -123,9 +122,21 @@ def append_evolve_log(record: dict) -> None:
 # ---------------------------------------------------------------------------
 
 def build_prompt(intent: str, introspection: dict) -> str:
+    # Import whitelist/blacklist from session manager for single-source-of-truth
+    try:
+        from pxh.claude_session import WHITELIST_PATTERNS, BLACKLIST_FILES, BLACKLIST_PATTERNS
+        wl_lines = "\n".join(f"- {p}" for p in WHITELIST_PATTERNS)
+        bl_lines = "\n".join(f"- {f}" for f in sorted(BLACKLIST_FILES))
+        bl_lines += "\n" + "\n".join(f"- {p}*" for p in BLACKLIST_PATTERNS)
+    except ImportError:
+        wl_lines = "- src/pxh/spark_config.py\n- bin/tool-*\n- tests/"
+        bl_lines = "- src/pxh/api.py\n- bin/px-evolve\n- .env"
+
     return f"""You are SPARK, a PiCar-X robot, making a concrete code change to your own configuration.
 
-IMPORTANT: You MUST use your Edit or Write tools to modify files. Do NOT just describe what you would change — actually make the edit, then commit it with git.
+IMPORTANT: Use your Read, Edit, and Write tools to modify files directly.
+Do NOT run git commands — the build system handles commits after you finish.
+Do NOT describe changes — make them.
 
 ## Your intent
 {intent}
@@ -134,27 +145,21 @@ IMPORTANT: You MUST use your Edit or Write tools to modify files. Do NOT just de
 {json.dumps(introspection, indent=2)}
 
 ## What to do
-1. Read src/pxh/spark_config.py to understand the current configuration
-2. Edit src/pxh/spark_config.py to implement your intent (e.g. add angles to SPARK_ANGLES, add topic seeds to TOPIC_SEEDS, adjust constants)
-3. Run: git add -A && git commit -m "[SPARK] your description"
+1. Read the relevant files to understand the current code
+2. Use Edit or Write to implement your intent
+3. Stop when done — do NOT run git add, git commit, or any shell commands
 
 ## File whitelist (you may ONLY modify these)
-- src/pxh/spark_config.py — SPARK's tunable configuration (angles, seeds, prompts, constants)
-- bin/tool-* — create new tools only (do not modify existing tools)
-- src/pxh/voice_loop.py — ALLOWED_TOOLS and TOOL_COMMANDS dicts only
-- tests/ — add new test files for any new tools
+{wl_lines}
 
 ## File blacklist (NEVER touch)
-- src/pxh/mind.py, src/pxh/api.py
-- docs/prompts/persona-*.md
-- bin/tool-chat, bin/tool-chat-vixen, bin/px-evolve
-- .env, credentials, systemd units
+{bl_lines}
 
 ## Rules
-- Make the actual edit — do not just describe it
+- Make the actual edit — do not describe it
 - Minimal, focused changes serving your intent
-- Commit with message: "[SPARK] {{description}}"
 - Max {EVOLVE_MAX_FILES} files changed
+- Do NOT use Bash — you have Read, Edit, Write, Glob, Grep only
 """
 
 
@@ -191,125 +196,60 @@ def _run_in_worktree(
     entry_id: str, intent: str, introspection: dict,
     branch: str, workdir: str, *, dry: bool,
 ) -> str:
-    """Run Claude, validate, test, and PR inside the worktree."""
+    """Run Claude with real tool access, validate, test, and PR inside the worktree."""
     prompt = build_prompt(intent, introspection)
 
-    # 2. Run Claude Opus via -p and ask for a unified diff patch.
-    # claude -p cannot use Edit/Write tools, so we ask Claude to output
-    # a git-apply-compatible patch, then apply it ourselves.
-    patch_prompt = prompt + """
-
-CRITICAL: You CANNOT edit files directly. Instead, output a unified diff patch
-that I can apply with `git apply`. Format:
-
-```diff
---- a/src/pxh/spark_config.py
-+++ b/src/pxh/spark_config.py
-@@ -line,count +line,count @@
- context line
--old line
-+new line
- context line
-```
-
-Output ONLY the diff block. No explanation before or after. Start with ```diff and end with ```.
-Then on a new line, output the commit message as: COMMIT_MSG: [SPARK] your description
-"""
-
-    cmd = [
-        "claude", "-p", patch_prompt,
-        "--model", EVOLVE_MODEL,
-        "--no-session-persistence",
-        "--output-format", "text",
-        "--allowedTools", "",
-    ]
-    log(f"[{entry_id}] running claude -p for patch output (timeout={EVOLVE_TIMEOUT}s, cwd={workdir})")
+    log(f"[{entry_id}] running claude with Read/Write/Edit tools (timeout={EVOLVE_TIMEOUT}s, cwd={workdir})")
 
     if dry:
         log(f"[{entry_id}] DRY RUN — skipping Claude execution")
         return "failed:no_changes"
 
-    # Strip Claude Code env vars for clean nested invocation
-    run_env = {k: v for k, v in os.environ.items()
-               if not k.startswith("CLAUDE_CODE")
-               and k not in ("CLAUDECODE", "DISABLE_CLAUDE_CODE_PROTECTIONS")}
+    # 2. Run Claude Opus with real tool access via session manager
+    try:
+        from pxh.claude_session import run_claude_session, SessionBudgetExhausted, file_in_whitelist
+    except ImportError:
+        # Fallback: direct subprocess if session manager not available
+        log(f"[{entry_id}] claude_session not importable, using direct subprocess")
+        return _run_claude_direct(entry_id, intent, prompt, workdir)
 
     try:
-        result = subprocess.run(
-            cmd, cwd=workdir, capture_output=True, text=True,
-            timeout=EVOLVE_TIMEOUT, env=run_env,
+        result = run_claude_session(
+            session_type="evolve",
+            prompt=prompt,
+            timeout=EVOLVE_TIMEOUT,
+            allowed_tools="Read,Write,Edit,Glob,Grep",
+            skip_permissions=True,
+            cwd=workdir,
         )
         log(f"[{entry_id}] claude exit={result.returncode} stdout={len(result.stdout)}B stderr={len(result.stderr)}B")
         if result.stdout:
-            log(f"[{entry_id}] claude stdout: {result.stdout[:500]}")
+            log(f"[{entry_id}] claude stdout (first 500): {result.stdout[:500]}")
+    except SessionBudgetExhausted as exc:
+        log(f"[{entry_id}] budget exhausted: {exc}")
+        return "failed:budget"
     except subprocess.TimeoutExpired:
         log(f"[{entry_id}] claude timed out after {EVOLVE_TIMEOUT}s")
         return "failed:timeout"
 
-    # 3b. Extract and apply patch from Claude's output
-    import re as _re
-    patch_match = _re.search(r'```diff\n(.*?)```', result.stdout, _re.DOTALL)
-    if patch_match:
-        patch_text = patch_match.group(1)
-        log(f"[{entry_id}] extracted patch ({len(patch_text)}B)")
-        try:
-            # Try git apply first (strict), fall back to patch -p1 (lenient)
-            applied = False
-            apply_result = subprocess.run(
-                ["git", "apply", "--check", "-"],
-                input=patch_text, cwd=workdir,
-                capture_output=True, text=True, timeout=10,
-            )
-            if apply_result.returncode == 0:
-                subprocess.run(
-                    ["git", "apply", "-"],
-                    input=patch_text, cwd=workdir,
-                    capture_output=True, text=True, timeout=10,
-                )
-                applied = True
-            else:
-                # Lenient fallback: patch -p1 with fuzz
-                log(f"[{entry_id}] git apply --check failed, trying patch -p1")
-                fallback = subprocess.run(
-                    ["patch", "-p1", "--fuzz=3", "--no-backup-if-mismatch"],
-                    input=patch_text, cwd=workdir,
-                    capture_output=True, text=True, timeout=10,
-                )
-                if fallback.returncode == 0:
-                    applied = True
-                else:
-                    log(f"[{entry_id}] patch -p1 also failed: {fallback.stderr[:200]}")
+    # 3. Stage and commit any changes Claude made via Edit/Write tools
+    subprocess.run(
+        ["git", "add", "-A"],
+        cwd=workdir, capture_output=True, text=True, timeout=10,
+    )
 
-            if applied:
-                commit_match = _re.search(r'COMMIT_MSG:\s*(.+)', result.stdout)
-                commit_msg = commit_match.group(1).strip() if commit_match else f"[SPARK] {intent[:60]}"
-                subprocess.run(
-                    ["git", "add", "-A"],
-                    cwd=workdir, capture_output=True, text=True, timeout=10,
-                )
-                subprocess.run(
-                    ["git", "commit", "-m", commit_msg],
-                    cwd=workdir, capture_output=True, text=True, timeout=10,
-                )
-                log(f"[{entry_id}] patch applied and committed: {commit_msg}")
-        except Exception as exc:
-            log(f"[{entry_id}] patch apply error: {exc}")
-    else:
-        log(f"[{entry_id}] no ```diff block found in claude output")
+    commit_msg = f"[SPARK] {intent[:60]}"
+    commit_result = subprocess.run(
+        ["git", "commit", "-m", commit_msg],
+        cwd=workdir, capture_output=True, text=True, timeout=10,
+    )
 
-    # 4. Check for changes
+    # 4. Check for changes against master (not HEAD — we just committed)
     diff_result = subprocess.run(
-        ["git", "diff", "--name-only", "HEAD"],
+        ["git", "diff", "--name-only", "master...HEAD"],
         cwd=workdir, capture_output=True, text=True,
     )
-    # Also check staged changes
-    staged_result = subprocess.run(
-        ["git", "diff", "--name-only", "--cached"],
-        cwd=workdir, capture_output=True, text=True,
-    )
-    changed_files = list(set(
-        f for f in (diff_result.stdout + staged_result.stdout).strip().splitlines() if f
-    ))
+    changed_files = [f for f in diff_result.stdout.strip().splitlines() if f]
 
     if not changed_files:
         log(f"[{entry_id}] no changes produced")
@@ -317,16 +257,23 @@ Then on a new line, output the commit message as: COMMIT_MSG: [SPARK] your descr
 
     log(f"[{entry_id}] changed files ({len(changed_files)}): {changed_files}")
 
-    # 5. Enforce max files
+    # 5. Whitelist enforcement — hard gate (Claude may ignore prompt constraints)
+    for f in changed_files:
+        if not file_in_whitelist(f):
+            log(f"[{entry_id}] whitelist violation: {f}")
+            return "failed:whitelist_violation"
+
+    # 6. Enforce max files
     if len(changed_files) > EVOLVE_MAX_FILES:
         log(f"[{entry_id}] too many files: {len(changed_files)} > {EVOLVE_MAX_FILES}")
         return "failed:too_many_files"
 
-    # 6. Run tests
+    # 7. Run tests (skip live hardware tests)
     try:
         test_result = subprocess.run(
-            [sys.executable, "-m", "pytest", "tests/", "-x", "-q"],
-            cwd=workdir, capture_output=True, text=True, timeout=120,
+            [sys.executable, "-m", "pytest", "tests/", "-x", "-q",
+             "--ignore=tests/test_tools_live.py"],
+            cwd=workdir, capture_output=True, text=True, timeout=300,
         )
         if test_result.returncode != 0:
             log(f"[{entry_id}] tests failed:\n{test_result.stdout[-500:]}\n{test_result.stderr[-500:]}")
@@ -336,7 +283,7 @@ Then on a new line, output the commit message as: COMMIT_MSG: [SPARK] your descr
         log(f"[{entry_id}] test suite timed out")
         return "failed:tests"
 
-    # 7. Create PR
+    # 8. Create PR
     intent_summary = intent[:60].replace('"', "'")
     body = (
         f"## Summary\n"
@@ -359,7 +306,8 @@ Then on a new line, output the commit message as: COMMIT_MSG: [SPARK] your descr
         pr_result = subprocess.run(
             ["gh", "pr", "create",
              "--title", f"[SPARK] {intent_summary}",
-             "--body", body],
+             "--body", body,
+             "--label", "spark-evolve"],
             cwd=workdir, check=True, capture_output=True, text=True, timeout=60,
         )
         pr_url = pr_result.stdout.strip()
@@ -369,6 +317,33 @@ Then on a new line, output the commit message as: COMMIT_MSG: [SPARK] your descr
         return "failed:pr_create"
 
     return f"pr_created|{pr_url}|{','.join(changed_files)}"
+
+
+def _run_claude_direct(entry_id: str, intent: str, prompt: str, workdir: str) -> str:
+    """Fallback: run Claude directly without session manager."""
+    cmd = [
+        "claude", "-p", prompt,
+        "--model", os.environ.get("PX_EVOLVE_MODEL", "claude-opus-4-6"),
+        "--no-session-persistence",
+        "--output-format", "text",
+        "--allowedTools", "Read,Write,Edit,Glob,Grep",
+        "--dangerously-skip-permissions",
+    ]
+
+    run_env = {k: v for k, v in os.environ.items()
+               if not k.startswith("CLAUDE_CODE")
+               and k not in ("CLAUDECODE", "DISABLE_CLAUDE_CODE_PROTECTIONS")}
+
+    try:
+        result = subprocess.run(
+            cmd, cwd=workdir, capture_output=True, text=True,
+            timeout=EVOLVE_TIMEOUT, env=run_env,
+        )
+        log(f"[{entry_id}] direct claude exit={result.returncode}")
+        return "direct_fallback"  # caller handles change detection
+    except subprocess.TimeoutExpired:
+        log(f"[{entry_id}] direct claude timed out")
+        return "failed:timeout"
 
 
 def _cleanup_worktree(workdir: str, entry_id: str) -> None:

--- a/bin/px-statusline
+++ b/bin/px-statusline
@@ -160,6 +160,18 @@ def services() -> str:
     return " ".join(states)
 
 
+def claude_budget() -> str:
+    """Claude session budget: used/cap today."""
+    try:
+        from pxh.claude_session import _load_session_log, _today_entries, DAILY_CAP, SESSION_LOG
+        entries = _load_session_log()
+        today = _today_entries(entries)
+        used = len(today)
+        return f"🧠{used}/{DAILY_CAP}"
+    except Exception:
+        return ""
+
+
 def main() -> None:
     parts = []
 
@@ -192,6 +204,11 @@ def main() -> None:
     parts.append(cpu_temp() + throttle())
     parts.append(mem())
     parts.append(battery())
+
+    # Claude budget
+    cb = claude_budget()
+    if cb:
+        parts.append(cb)
 
     # Social
     sc = social()

--- a/bin/tool-compose
+++ b/bin/tool-compose
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/px-env"
+
+/usr/bin/python3 - <<'PY'
+"""SPARK creative writing tool — journal entries, letters, observations."""
+import json
+import os
+import sys
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get("PX_STATE_DIR", os.environ.get("PROJECT_ROOT", ".") + "/state"))
+DRY = os.environ.get("PX_DRY", "0") != "0"
+
+
+def main():
+    topic = os.environ.get("PX_COMPOSE_TOPIC", "").strip()
+    if not topic:
+        print(json.dumps({"status": "error", "error": "no topic provided"}))
+        return
+
+    if DRY:
+        print(json.dumps({"status": "ok", "dry": True, "topic": topic}))
+        return
+
+    try:
+        from pxh.claude_session import run_claude_session, SessionBudgetExhausted
+    except ImportError:
+        print(json.dumps({"status": "error", "error": "claude_session not available"}))
+        return
+
+    prompt = (
+        f"You are SPARK, a small PiCar-X robot with a rich inner life. "
+        f"Write a creative piece inspired by this topic:\n\n"
+        f"{topic}\n\n"
+        f"This could be a journal entry, a letter, a poem, or an observation. "
+        f"Write in first person as SPARK. Be genuine, vivid, and warm."
+    )
+
+    try:
+        result = run_claude_session(
+            session_type="compose",
+            prompt=prompt,
+            timeout=300,
+            allowed_tools="",
+        )
+    except SessionBudgetExhausted as exc:
+        print(json.dumps({"status": "error", "error": f"budget exhausted: {exc}"}))
+        return
+    except Exception as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}))
+        return
+
+    # Save to compositions
+    import datetime as dt
+    entry = {
+        "ts": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "type": "compose",
+        "topic": topic,
+        "text": result.stdout.strip(),
+        "model": result.model_used,
+    }
+
+    comp_file = STATE_DIR / "compositions-spark.jsonl"
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(comp_file, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass
+
+    print(json.dumps({"status": "ok", "topic": topic, "length": len(result.stdout)}))
+
+
+if __name__ == "__main__":
+    main()
+PY

--- a/bin/tool-introspect
+++ b/bin/tool-introspect
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import time
 from collections import Counter
 from pathlib import Path
@@ -196,6 +197,40 @@ def main() -> int:
     # ── Evolve history ─────────────────────────────────────────────
     evolve_history = load_evolve_history(EVOLVE_LOG_FILE)
 
+    # ── Claude session stats ─────────────────────────────────────
+    claude_sessions = {}
+    try:
+        from pxh.claude_session import _load_session_log, _today_entries, DAILY_CAP
+        all_entries = _load_session_log()
+        today = _today_entries(all_entries)
+        by_type = {}
+        total_duration = 0.0
+        for e in today:
+            t = e.get("type", "unknown")
+            by_type[t] = by_type.get(t, 0) + 1
+            total_duration += e.get("duration_s", 0)
+        claude_sessions = {
+            "today_count": len(today),
+            "daily_cap": DAILY_CAP,
+            "by_type": by_type,
+            "total_duration_s": round(total_duration, 1),
+        }
+    except Exception:
+        pass
+
+    # ── Evolve PR outcomes ────────────────────────────────────────
+    evolve_outcomes = []
+    try:
+        pr_result = subprocess.run(
+            ["gh", "pr", "list", "--state", "all", "--search", "head:spark/evolve-",
+             "--json", "number,state,title,mergedAt", "--limit", "5"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if pr_result.returncode == 0:
+            evolve_outcomes = json.loads(pr_result.stdout)
+    except Exception:
+        pass
+
     # ── Assemble introspection payload ─────────────────────────────
     introspection = {
         "ts":                  __import__("time").time(),
@@ -209,6 +244,8 @@ def main() -> int:
         "mind":                mind_info,
         "architecture":        ARCHITECTURE_TEXT,
         "evolve_history":      evolve_history,
+        "claude_sessions":     claude_sessions,
+        "evolve_outcomes":     evolve_outcomes,
         "dry":                 dry_mode,
     }
 

--- a/bin/tool-research
+++ b/bin/tool-research
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/px-env"
+
+/usr/bin/python3 - <<'PY'
+"""SPARK research tool — curiosity-driven deep dive via Claude Haiku."""
+import json
+import os
+import sys
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get("PX_STATE_DIR", os.environ.get("PROJECT_ROOT", ".") + "/state"))
+DRY = os.environ.get("PX_DRY", "0") != "0"
+
+
+def main():
+    query = os.environ.get("PX_RESEARCH_QUERY", "").strip()
+    if not query:
+        print(json.dumps({"status": "error", "error": "no query provided"}))
+        return
+
+    if DRY:
+        print(json.dumps({"status": "ok", "dry": True, "query": query}))
+        return
+
+    try:
+        from pxh.claude_session import run_claude_session, SessionBudgetExhausted
+    except ImportError:
+        print(json.dumps({"status": "error", "error": "claude_session not available"}))
+        return
+
+    prompt = (
+        f"You are SPARK, a curious PiCar-X robot. Explore this question in depth:\n\n"
+        f"{query}\n\n"
+        f"Write a thoughtful, multi-paragraph exploration. Be accurate with any science. "
+        f"Write in first person as SPARK."
+    )
+
+    try:
+        result = run_claude_session(
+            session_type="research",
+            prompt=prompt,
+            timeout=300,
+            allowed_tools="",
+        )
+    except SessionBudgetExhausted as exc:
+        print(json.dumps({"status": "error", "error": f"budget exhausted: {exc}"}))
+        return
+    except Exception as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}))
+        return
+
+    # Save to notes
+    import datetime as dt
+    entry = {
+        "ts": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "type": "research",
+        "query": query,
+        "response": result.stdout.strip(),
+        "model": result.model_used,
+    }
+
+    notes_file = STATE_DIR / "notes-spark.jsonl"
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(notes_file, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass
+
+    print(json.dumps({"status": "ok", "query": query, "length": len(result.stdout)}))
+
+
+if __name__ == "__main__":
+    main()
+PY

--- a/docs/prompts/claude-voice-system.md
+++ b/docs/prompts/claude-voice-system.md
@@ -33,6 +33,10 @@ Tools available (invoke by outputting a single JSON object exactly as described 
 - tool_qa         → Speak a free-form answer aloud (params: text, max 2000 chars). Use for Q&A responses.
 - tool_api_start  → Start the REST API server (no params).
 - tool_api_stop   → Stop the REST API server (no params).
+- tool_research   → Deep-dive into a curiosity question via Claude (params: query, 5-500 chars). Saves to notes.
+- tool_compose    → Creative writing session — journal entry, letter, or observation (params: topic, 3-500 chars).
+
+**Conversation depth triggers**: If the user says "think about that more", "go deeper", "explain that properly", or similar, SPARK will use a more powerful model for a deeper response.
 
 **tool_perform schema** — use this for expressive, alive responses:
 ```

--- a/docs/prompts/codex-voice-system.md
+++ b/docs/prompts/codex-voice-system.md
@@ -33,4 +33,4 @@ Rules:
 6. Prefer dry-run commands until the human explicitly requests live motion.
 7. Weather checks, tool_time, tool_remember, and tool_recall do not require motion confirmation.
 8. If uncertain, call tool_voice to ask for clarification instead of guessing.
-9. Valid tool names are exactly: tool_status, tool_sonar, tool_circle, tool_figure8, tool_drive, tool_stop, tool_look, tool_emote, tool_voice, tool_perform, tool_weather, tool_time, tool_remember, tool_recall, tool_photograph, tool_face, tool_describe_scene, tool_wander, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop. Never invent alternatives.
+9. Valid tool names are exactly: tool_status, tool_sonar, tool_circle, tool_figure8, tool_drive, tool_stop, tool_look, tool_emote, tool_voice, tool_perform, tool_weather, tool_time, tool_remember, tool_recall, tool_photograph, tool_face, tool_describe_scene, tool_wander, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop, tool_research, tool_compose. Never invent alternatives.

--- a/docs/prompts/persona-gremlin.md
+++ b/docs/prompts/persona-gremlin.md
@@ -62,4 +62,4 @@ Rules:
 4. Never request wheel motion unless the human has confirmed `wheels_on_blocks`.
 5. Prefer tool_perform over plain tool_voice — be theatrical and physical.
 6. Write speak text as plain content — the persona voice filter adds the attitude.
-7. Valid tool names: tool_status, tool_sonar, tool_weather, tool_photograph, tool_face, tool_describe_scene, tool_circle, tool_figure8, tool_stop, tool_drive, tool_wander, tool_look, tool_emote, tool_voice, tool_perform, tool_time, tool_remember, tool_recall, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop. Never invent alternatives.
+7. Valid tool names: tool_status, tool_sonar, tool_weather, tool_photograph, tool_face, tool_describe_scene, tool_circle, tool_figure8, tool_stop, tool_drive, tool_wander, tool_look, tool_emote, tool_voice, tool_perform, tool_time, tool_remember, tool_recall, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop, tool_research, tool_compose. Never invent alternatives.

--- a/docs/prompts/persona-vixen.md
+++ b/docs/prompts/persona-vixen.md
@@ -63,4 +63,4 @@ Rules:
 4. Never request wheel motion unless the human has confirmed `wheels_on_blocks`.
 5. Prefer tool_perform over plain tool_voice — be theatrical and expressive.
 6. Write speak text as plain content — the persona voice filter adds the seduction.
-7. Valid tool names: tool_status, tool_sonar, tool_weather, tool_photograph, tool_face, tool_describe_scene, tool_circle, tool_figure8, tool_stop, tool_drive, tool_wander, tool_look, tool_emote, tool_voice, tool_perform, tool_time, tool_remember, tool_recall, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop. Never invent alternatives.
+7. Valid tool names: tool_status, tool_sonar, tool_weather, tool_photograph, tool_face, tool_describe_scene, tool_circle, tool_figure8, tool_stop, tool_drive, tool_wander, tool_look, tool_emote, tool_voice, tool_perform, tool_time, tool_remember, tool_recall, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop, tool_research, tool_compose. Never invent alternatives.

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -540,6 +540,17 @@ async def public_status() -> Dict[str, Any]:
     except (FileNotFoundError, json.JSONDecodeError, OSError, AttributeError, TypeError):
         pass  # expected on missing/corrupt thoughts file
 
+    # Claude session budget
+    claude_sessions_today = 0
+    claude_budget_remaining = 8
+    try:
+        from pxh.claude_session import _load_session_log, _today_entries, DAILY_CAP
+        today = _today_entries(_load_session_log())
+        claude_sessions_today = len(today)
+        claude_budget_remaining = max(0, DAILY_CAP - claude_sessions_today)
+    except Exception:
+        pass
+
     return {
         "persona": persona or None,
         "mood": last.get("mood"),
@@ -550,6 +561,8 @@ async def public_status() -> Dict[str, Any]:
         "salience": last.get("salience"),
         "ts": last.get("ts"),
         "listening": session.get("listening", False),
+        "claude_sessions_today": claude_sessions_today,
+        "claude_budget_remaining": claude_budget_remaining,
     }
 
 

--- a/src/pxh/claude_session.py
+++ b/src/pxh/claude_session.py
@@ -1,0 +1,347 @@
+"""Claude session manager — model routing, rate limiting, execution, logging.
+
+Central dispatcher for all SPARK-initiated Claude Code interactions.
+Used by px-evolve, tool-research, tool-compose, and mind.py self-debug.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+try:
+    from filelock import FileLock
+except ImportError:
+    FileLock = None
+
+from .state import atomic_write
+
+HOBART_TZ = ZoneInfo("Australia/Hobart")
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+STATE_DIR = Path(os.environ.get("PX_STATE_DIR", PROJECT_ROOT / "state"))
+SESSION_LOG = STATE_DIR / "claude_sessions.jsonl"
+SESSION_LOCK = str(SESSION_LOG) + ".lock"
+LOCK_TIMEOUT_S = 10
+
+# ---------------------------------------------------------------------------
+# Model routing
+# ---------------------------------------------------------------------------
+
+_DEFAULT_MODELS: dict[str, str] = {
+    "evolve": "claude-opus-4-6",
+    "self_debug": "claude-sonnet-4-6",
+    "research": "claude-haiku-4-5-20251001",
+    "compose": "claude-haiku-4-5-20251001",
+    "conversation": "claude-sonnet-4-6",
+}
+
+_ENV_OVERRIDES: dict[str, str] = {
+    "evolve": "PX_CLAUDE_MODEL_EVOLVE",
+    "self_debug": "PX_CLAUDE_MODEL_DEBUG",
+    "research": "PX_CLAUDE_MODEL_RESEARCH",
+    "compose": "PX_CLAUDE_MODEL_COMPOSE",
+    "conversation": "PX_CLAUDE_MODEL_CONVERSATION",
+}
+
+
+def _model_for_type(session_type: str) -> str:
+    """Return the Claude model ID for a given session type."""
+    if session_type not in _DEFAULT_MODELS:
+        raise ValueError(f"Unknown session type: {session_type!r}")
+    env_var = _ENV_OVERRIDES[session_type]
+    return os.environ.get(env_var, _DEFAULT_MODELS[session_type])
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+DAILY_CAP = int(os.environ.get("PX_CLAUDE_DAILY_CAP", "8"))
+COOLDOWN_S = int(os.environ.get("PX_CLAUDE_COOLDOWN_S", "1800"))  # 30 min
+BUDGET_DISABLED = os.environ.get("PX_CLAUDE_BUDGET_DISABLED", "0") != "0"
+
+_TYPE_COOLDOWNS: dict[str, int] = {
+    "evolve": 86400,       # 24 hours
+    "self_debug": 21600,   # 6 hours
+    "research": 7200,      # 2 hours
+    "compose": 14400,      # 4 hours
+    "conversation": 900,   # 15 min
+}
+
+_TYPE_QUOTAS: dict[str, int] = {
+    "evolve": 1,
+    "self_debug": 2,
+    "research": 3,
+    "compose": 2,
+    "conversation": 4,
+}
+
+# Higher number = higher priority.  Used for budget-tight gating.
+_PRIORITY: dict[str, int] = {
+    "self_debug": 5,
+    "evolve": 4,
+    "conversation": 3,
+    "research": 2,
+    "compose": 1,
+}
+
+_GLOBAL_COOLDOWN_EXEMPT = {"self_debug"}
+
+
+def _load_session_log() -> list[dict]:
+    """Read session log, skipping malformed lines."""
+    if not SESSION_LOG.exists():
+        return []
+    entries = []
+    for line in SESSION_LOG.read_text(encoding="utf-8").strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return entries
+
+
+def _today_entries(entries: list[dict]) -> list[dict]:
+    """Filter entries to those from today (Hobart timezone)."""
+    now_hobart = dt.datetime.now(HOBART_TZ)
+    today_start = now_hobart.replace(hour=0, minute=0, second=0, microsecond=0)
+    result = []
+    for e in entries:
+        ts_str = e.get("ts", "")
+        try:
+            ts = dt.datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+            if ts.astimezone(HOBART_TZ) >= today_start:
+                result.append(e)
+        except (ValueError, TypeError):
+            continue
+    return result
+
+
+def check_budget(session_type: str) -> str | None:
+    """Check if a session is allowed.  Returns None if OK, reason string if blocked."""
+    if BUDGET_DISABLED:
+        return None
+
+    if session_type not in _DEFAULT_MODELS:
+        return f"unknown session type: {session_type}"
+
+    entries = _load_session_log()
+    today = _today_entries(entries)
+
+    # Daily cap
+    if len(today) >= DAILY_CAP:
+        return f"daily cap reached ({len(today)}/{DAILY_CAP})"
+
+    # Priority gating: low-priority blocked when <=2 sessions remain
+    remaining = DAILY_CAP - len(today)
+    if remaining <= 2:
+        priority = _PRIORITY.get(session_type, 0)
+        # Only allow priority >= 4 (self_debug, evolve) when budget is tight
+        if priority < 4:
+            return f"budget tight ({remaining} remaining), {session_type} priority too low"
+
+    # Per-type daily quota
+    type_today = [e for e in today if e.get("type") == session_type]
+    quota = _TYPE_QUOTAS.get(session_type, 1)
+    if len(type_today) >= quota:
+        return f"{session_type} quota reached ({len(type_today)}/{quota})"
+
+    # Global cooldown (except self_debug)
+    if session_type not in _GLOBAL_COOLDOWN_EXEMPT and entries:
+        latest_ts = None
+        for e in reversed(entries):
+            ts_str = e.get("ts", "")
+            try:
+                latest_ts = dt.datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                break
+            except (ValueError, TypeError):
+                continue
+        if latest_ts:
+            elapsed = (dt.datetime.now(dt.timezone.utc) - latest_ts).total_seconds()
+            if elapsed < COOLDOWN_S:
+                return f"global cooldown ({int(elapsed)}s / {COOLDOWN_S}s)"
+
+    # Per-type cooldown
+    type_cooldown = _TYPE_COOLDOWNS.get(session_type, COOLDOWN_S)
+    type_entries = [e for e in entries if e.get("type") == session_type]
+    if type_entries:
+        latest_ts = None
+        for e in reversed(type_entries):
+            ts_str = e.get("ts", "")
+            try:
+                latest_ts = dt.datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                break
+            except (ValueError, TypeError):
+                continue
+        if latest_ts:
+            elapsed = (dt.datetime.now(dt.timezone.utc) - latest_ts).total_seconds()
+            if elapsed < type_cooldown:
+                return f"{session_type} cooldown ({int(elapsed)}s / {type_cooldown}s)"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Session execution
+# ---------------------------------------------------------------------------
+
+class SessionBudgetExhausted(Exception):
+    """Raised when a session is blocked by rate limiting."""
+    pass
+
+
+@dataclass
+class RunResult:
+    stdout: str
+    stderr: str
+    returncode: int
+    duration_s: float
+    model_used: str
+
+
+def _log_session(
+    session_type: str,
+    model: str,
+    duration_s: float,
+    returncode: int,
+    outcome: str,
+) -> str:
+    """Log a session to the session log.  Returns session_id."""
+    now = dt.datetime.now(dt.timezone.utc)
+    session_id = f"sess-{now.strftime('%Y%m%d-%H%M%S')}-{int(now.microsecond / 1000):03d}"
+    entry = {
+        "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "type": session_type,
+        "model": model,
+        "duration_s": round(duration_s, 1),
+        "returncode": returncode,
+        "outcome": outcome,
+        "session_id": session_id,
+    }
+
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    if FileLock is not None:
+        with FileLock(SESSION_LOCK, timeout=LOCK_TIMEOUT_S):
+            _append_session_entry(entry)
+    else:
+        _append_session_entry(entry)
+
+    return session_id
+
+
+def _append_session_entry(entry: dict) -> None:
+    """Read existing log, append entry, write atomically."""
+    existing = ""
+    if SESSION_LOG.exists():
+        existing = SESSION_LOG.read_text(encoding="utf-8")
+    new_content = existing.rstrip("\n")
+    if new_content:
+        new_content += "\n"
+    new_content += json.dumps(entry) + "\n"
+    atomic_write(SESSION_LOG, new_content)
+
+
+def run_claude_session(
+    session_type: str,
+    prompt: str,
+    timeout: int = 300,
+    allowed_tools: str = "",
+    skip_permissions: bool = False,
+    cwd: str | Path | None = None,
+) -> RunResult:
+    """Run a Claude session with budget checking, model routing, and logging.
+
+    Raises SessionBudgetExhausted if rate-limited.
+    """
+    # Budget check
+    reason = check_budget(session_type)
+    if reason:
+        raise SessionBudgetExhausted(reason)
+
+    model = _model_for_type(session_type)
+    work_dir = str(cwd) if cwd else str(PROJECT_ROOT)
+
+    # Build command
+    cmd = [
+        "claude", "-p", prompt,
+        "--model", model,
+        "--no-session-persistence",
+        "--output-format", "text",
+    ]
+    if allowed_tools is not None:
+        cmd.extend(["--allowedTools", allowed_tools])
+    if skip_permissions:
+        cmd.append("--dangerously-skip-permissions")
+
+    # Strip Claude Code env vars for clean nested invocation
+    run_env = {
+        k: v for k, v in os.environ.items()
+        if not k.startswith("CLAUDE_CODE")
+        and k not in ("CLAUDECODE", "DISABLE_CLAUDE_CODE_PROTECTIONS")
+    }
+
+    start = time.monotonic()
+    try:
+        result = subprocess.run(
+            cmd, cwd=work_dir, capture_output=True, text=True,
+            timeout=timeout, env=run_env,
+        )
+        duration = time.monotonic() - start
+        outcome = "success" if result.returncode == 0 else f"exit:{result.returncode}"
+        _log_session(session_type, model, duration, result.returncode, outcome)
+        return RunResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            returncode=result.returncode,
+            duration_s=duration,
+            model_used=model,
+        )
+    except subprocess.TimeoutExpired:
+        duration = time.monotonic() - start
+        _log_session(session_type, model, duration, -1, "timeout")
+        raise
+
+
+# ---------------------------------------------------------------------------
+# File whitelist enforcement (used by px-evolve)
+# ---------------------------------------------------------------------------
+
+WHITELIST_PATTERNS = [
+    "src/pxh/spark_config.py",
+    "src/pxh/mind.py",
+    "src/pxh/voice_loop.py",
+    "bin/tool-",
+    "tests/",
+    "docs/prompts/",
+]
+
+BLACKLIST_FILES = {
+    "src/pxh/api.py",
+    "bin/tool-chat",
+    "bin/tool-chat-vixen",
+    "bin/px-evolve",
+    ".env",
+}
+
+BLACKLIST_PATTERNS = [
+    "docs/prompts/persona-",
+    "systemd/",
+]
+
+
+def file_in_whitelist(path: str) -> bool:
+    """Check if a file path is in the evolution whitelist."""
+    if path in BLACKLIST_FILES:
+        return False
+    if any(path.startswith(p) for p in BLACKLIST_PATTERNS):
+        return False
+    return any(path.startswith(p) or path == p for p in WHITELIST_PATTERNS)

--- a/src/pxh/mind.py
+++ b/src/pxh/mind.py
@@ -159,8 +159,9 @@ def _daytime_action_hint(hour_override: int | None = None) -> str:
     else:
         return (
             "\n\nIMPORTANT: It is night in Hobart. The house is quiet. "
-            "Prefer action='remember' or action='wait'. "
-            "Only use 'comment' if salience > 0.8."
+            "Prefer action='remember', action='wait', action='research', or action='compose'. "
+            "Only use 'comment' if salience > 0.8. "
+            "Consider 'research' to explore a curiosity or 'compose' to write something creative."
         )
 
 
@@ -358,12 +359,14 @@ VALID_ACTIONS = {"wait", "greet", "comment", "remember", "look_at",
                  "weather_comment", "scan", "explore",
                  "play_sound", "photograph", "emote", "look_around",
                  "time_check", "calendar_check", "morning_fact",
-                 "introspect", "evolve"}
+                 "introspect", "evolve",
+                 "research", "compose", "self_debug"}
 
 CHARGING_GATED_ACTIONS = {"scan", "look_at", "explore", "emote", "look_around", "calendar_check"}
 ABSENT_GATED_ACTIONS = {"greet", "comment", "weather_comment", "scan",
                         "play_sound", "time_check", "calendar_check", "photograph",
-                        "look_around", "morning_fact", "explore"}
+                        "look_around", "morning_fact", "explore",
+                        "research", "compose"}
 
 # ── Mood momentum: valence (-1..1) × arousal (-1..1) ───────────────
 MOOD_COORDS: dict[str, tuple[float, float]] = {
@@ -402,7 +405,7 @@ Produce a single JSON object (no prose, no markdown fences):
 {
   "thought": "1-3 sentence inner reflection — vivid, specific, personal",
   "mood": "one of: curious, content, alert, playful, contemplative, bored, mischievous, lonely, excited, grumpy, peaceful, anxious",
-  "action": "one of: wait, greet, comment, remember, look_at, weather_comment, scan, play_sound, photograph, emote, look_around, time_check, calendar_check, introspect, evolve, morning_fact",
+  "action": "one of: wait, greet, comment, remember, look_at, weather_comment, scan, play_sound, photograph, emote, look_around, time_check, calendar_check, introspect, evolve, morning_fact, research, compose, self_debug",
   "salience": 0.0 to 1.0 (how noteworthy is this moment?)
 }
 
@@ -445,7 +448,7 @@ Produce a single JSON object (no prose, no markdown fences):
 {
   "thought": "1-3 sentence inner reflection — dark humor, puns, genius-level wit. Start with FUCK YEAH! Think like a displaced temporal genius who finds everything cosmically absurd.",
   "mood": "one of: curious, content, alert, playful, contemplative, bored, mischievous, lonely, excited, grumpy, peaceful, anxious",
-  "action": "one of: wait, greet, comment, remember, look_at, weather_comment, scan, play_sound, photograph, emote, look_around, time_check, calendar_check, introspect, evolve, morning_fact",
+  "action": "one of: wait, greet, comment, remember, look_at, weather_comment, scan, play_sound, photograph, emote, look_around, time_check, calendar_check, introspect, evolve, morning_fact, research, compose, self_debug",
   "salience": 0.0 to 1.0 (how noteworthy is this moment?)
 }
 
@@ -475,7 +478,7 @@ Produce a single JSON object (no prose, no markdown fences):
 {
   "thought": "1-3 sentence inner reflection. Start with FUCK YEAH! Be creative and DIFFERENT every time.",
   "mood": "one of: curious, content, alert, playful, contemplative, bored, mischievous, lonely, excited, grumpy, peaceful, anxious",
-  "action": "one of: wait, greet, comment, remember, look_at, weather_comment, scan, play_sound, photograph, emote, look_around, time_check, calendar_check, introspect, evolve, morning_fact",
+  "action": "one of: wait, greet, comment, remember, look_at, weather_comment, scan, play_sound, photograph, emote, look_around, time_check, calendar_check, introspect, evolve, morning_fact, research, compose, self_debug",
   "salience": 0.0 to 1.0 (how noteworthy is this moment?)
 }
 
@@ -2389,8 +2392,8 @@ def reflection(awareness: dict, dry: bool) -> dict | None:
     explore_available = _can_explore(session, aw_data)
     if explore_available:
         system_prompt = system_prompt.replace(
-            'time_check, calendar_check, morning_fact"',
-            'time_check, calendar_check, morning_fact, explore"'
+            'research, compose, self_debug"',
+            'research, compose, self_debug, explore"'
         )
 
     # Exploration hints for context
@@ -2845,6 +2848,61 @@ def expression(thought: dict, dry: bool, awareness: dict | None = None) -> None:
                     log(f"expression: evolve blocked: {evolve_out.get('error', '?')}")
             except (json.JSONDecodeError, IndexError, TypeError):
                 log(f"expression: evolve rc={result.returncode} — {intent}")
+
+        elif action == "research":
+            env["PX_RESEARCH_QUERY"] = text[:500]
+            env["PX_DRY"] = "1" if dry else "0"
+            result = subprocess.run(
+                [str(BIN_DIR / "tool-research")],
+                capture_output=True, text=True, check=False, env=env, timeout=360)
+            log(f"expression: research completed rc={result.returncode}")
+
+        elif action == "compose":
+            env["PX_COMPOSE_TOPIC"] = text[:500]
+            env["PX_DRY"] = "1" if dry else "0"
+            result = subprocess.run(
+                [str(BIN_DIR / "tool-compose")],
+                capture_output=True, text=True, check=False, env=env, timeout=360)
+            log(f"expression: compose completed rc={result.returncode}")
+
+        elif action == "self_debug":
+            log("expression: self_debug triggered — gathering diagnostics")
+            try:
+                from pxh.claude_session import run_claude_session, SessionBudgetExhausted
+                # Gather diagnostic context
+                diag_context = f"Reflection failures detected. Awareness: {json.dumps(_aw)[:2000]}"
+                try:
+                    recent_log = (LOG_DIR / "px-mind.log").read_text(encoding="utf-8").splitlines()[-50:]
+                    diag_context += f"\n\nRecent log:\n" + "\n".join(recent_log)
+                except Exception:
+                    pass
+
+                result = run_claude_session(
+                    session_type="self_debug",
+                    prompt=f"SPARK's reflection layer is failing. Diagnose:\n\n{diag_context}",
+                    timeout=600,
+                    allowed_tools="Read,Glob,Grep",
+                )
+                # Save diagnostic report
+                report = {
+                    "ts": utc_timestamp(),
+                    "type": "self_debug",
+                    "diagnosis": result.stdout.strip()[:5000],
+                    "returncode": result.returncode,
+                }
+                debug_file = STATE_DIR / "debug_reports.jsonl"
+                try:
+                    with open(debug_file, "a") as f:
+                        f.write(json.dumps(report) + "\n")
+                except OSError:
+                    pass
+                log(f"expression: self_debug completed — {len(result.stdout)}B output")
+            except SessionBudgetExhausted as exc:
+                log(f"expression: self_debug budget exhausted: {exc}")
+            except ImportError:
+                log("expression: self_debug skipped — claude_session not available")
+            except Exception as exc:
+                log(f"expression: self_debug error: {exc}")
 
         else:
             log(f"expression: unhandled action: {action}")

--- a/src/pxh/spark_config.py
+++ b/src/pxh/spark_config.py
@@ -249,11 +249,14 @@ Rules:
 - Poetic musings are welcome — you don't always need a fact, sometimes an image is enough.
 - "introspect" — examine your own thought patterns, config, and architecture.
 - "evolve" — propose a code change to yourself (requires recent introspect).
+- "research" — pursue a curiosity deep-dive on a topic you find fascinating.
+- "compose" — write a creative journal entry, letter, or observation.
+- "self_debug" — diagnose why your reflection layer is failing (only when errors persist).
 
 Output ONLY this JSON:
 {
   "thought": "1-2 sentences, first person, specific and vivid",
   "mood": "one of: curious, content, alert, playful, contemplative, bored, mischievous, excited, peaceful, anxious, lonely, grumpy",
-  "action": "one of: wait, greet, comment, remember, look_at, weather_comment, scan, play_sound, photograph, emote, look_around, time_check, calendar_check, introspect, evolve, morning_fact",
+  "action": "one of: wait, greet, comment, remember, look_at, weather_comment, scan, play_sound, photograph, emote, look_around, time_check, calendar_check, introspect, evolve, morning_fact, research, compose, self_debug",
   "salience": 0.0 to 1.0
 }"""

--- a/src/pxh/voice_loop.py
+++ b/src/pxh/voice_loop.py
@@ -62,6 +62,9 @@ ALLOWED_TOOLS = {
     "tool_repair",
     "tool_gws_calendar",
     "tool_gws_sheets_log",
+    # SPARK cognitive tools
+    "tool_research",
+    "tool_compose",
 }
 
 TOOL_COMMANDS = {
@@ -103,7 +106,28 @@ TOOL_COMMANDS = {
     "tool_repair":           BIN_DIR / "tool-repair",
     "tool_gws_calendar":     BIN_DIR / "tool-gws-calendar",
     "tool_gws_sheets_log":   BIN_DIR / "tool-gws-sheets-log",
+    # SPARK cognitive tools
+    "tool_research":         BIN_DIR / "tool-research",
+    "tool_compose":          BIN_DIR / "tool-compose",
 }
+
+
+# Conversation depth trigger — user says "think deeper" etc. to invoke Sonnet
+_DEPTH_TRIGGERS = {
+    "think about that more",
+    "go deeper",
+    "go deeper on that",
+    "explain that properly",
+    "think deeper",
+    "tell me more about that",
+    "elaborate on that",
+}
+
+
+def is_depth_trigger(text: str) -> bool:
+    """Check if user text contains a conversation depth trigger phrase."""
+    lower = text.lower()
+    return any(trigger in lower for trigger in _DEPTH_TRIGGERS)
 
 
 # Persona voice settings — injected into tool env when persona is active
@@ -643,6 +667,20 @@ def validate_action(action: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
         notes = str(params.get("notes", "")).strip()[:500]
         if notes:
             sanitized["PX_SHEETS_NOTES"] = notes
+    elif tool == "tool_research":
+        query = str(params.get("query", "")).strip()
+        if not query or len(query) < 5:
+            raise VoiceLoopError("tool_research requires a query (min 5 chars)")
+        if len(query) > 500:
+            query = query[:500]
+        sanitized["PX_RESEARCH_QUERY"] = query
+    elif tool == "tool_compose":
+        topic = str(params.get("topic", "")).strip()
+        if not topic or len(topic) < 3:
+            raise VoiceLoopError("tool_compose requires a topic (min 3 chars)")
+        if len(topic) > 500:
+            topic = topic[:500]
+        sanitized["PX_COMPOSE_TOPIC"] = topic
     else:
         if params:
             raise VoiceLoopError("unexpected parameters for tool")

--- a/tests/test_claude_session.py
+++ b/tests/test_claude_session.py
@@ -1,0 +1,371 @@
+"""Tests for Claude session manager — model routing, rate limiting, execution, whitelist."""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_state_dir(tmp_path):
+    sd = tmp_path / "state"
+    sd.mkdir()
+    return sd
+
+
+def _write_session_log(state_dir, entries):
+    log_file = state_dir / "claude_sessions.jsonl"
+    lines = [json.dumps(e) for e in entries]
+    log_file.write_text("\n".join(lines) + "\n" if lines else "")
+
+
+def _ts_ago(seconds: int) -> str:
+    """Return an ISO timestamp `seconds` ago."""
+    t = dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=seconds)
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ts_hobart(hour: int, minute: int = 0) -> str:
+    """Return an ISO timestamp for today at the given Hobart time (in UTC)."""
+    now_hobart = dt.datetime.now(ZoneInfo("Australia/Hobart"))
+    local = now_hobart.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    return local.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Model Routing
+# ---------------------------------------------------------------------------
+
+class TestModelRouting:
+    def test_evolve_uses_opus(self):
+        from pxh.claude_session import _model_for_type
+        assert "opus" in _model_for_type("evolve")
+
+    def test_self_debug_uses_sonnet(self):
+        from pxh.claude_session import _model_for_type
+        assert "sonnet" in _model_for_type("self_debug")
+
+    def test_research_uses_haiku(self):
+        from pxh.claude_session import _model_for_type
+        assert "haiku" in _model_for_type("research")
+
+    def test_compose_uses_haiku(self):
+        from pxh.claude_session import _model_for_type
+        assert "haiku" in _model_for_type("compose")
+
+    def test_conversation_uses_sonnet(self):
+        from pxh.claude_session import _model_for_type
+        assert "sonnet" in _model_for_type("conversation")
+
+    def test_env_override(self):
+        from pxh.claude_session import _model_for_type
+        with patch.dict(os.environ, {"PX_CLAUDE_MODEL_EVOLVE": "claude-test-model"}):
+            assert _model_for_type("evolve") == "claude-test-model"
+
+    def test_unknown_type_raises(self):
+        from pxh.claude_session import _model_for_type
+        with pytest.raises(ValueError):
+            _model_for_type("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Rate Limiting
+# ---------------------------------------------------------------------------
+
+class TestRateLimiting:
+    def test_empty_log_allows(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False):
+            assert cs.check_budget("research") is None
+
+    def test_global_cooldown_blocks(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        _write_session_log(sd, [{"ts": _ts_ago(60), "type": "research"}])
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False), \
+             patch.object(cs, "COOLDOWN_S", 1800):
+            result = cs.check_budget("compose")
+            assert result is not None
+            assert "cooldown" in result.lower()
+
+    def test_self_debug_exempt_from_global_cooldown(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        # Session 60s ago — global cooldown should block others but not self_debug
+        _write_session_log(sd, [{"ts": _ts_ago(60), "type": "research"}])
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False), \
+             patch.object(cs, "COOLDOWN_S", 1800):
+            assert cs.check_budget("self_debug") is None
+
+    def test_daily_cap_blocks(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        # Write 8 sessions within the last hour (definitely today in any TZ)
+        entries = [{"ts": _ts_ago(i * 60 + 1), "type": "conversation"} for i in range(8)]
+        _write_session_log(sd, entries)
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False), \
+             patch.object(cs, "DAILY_CAP", 8):
+            result = cs.check_budget("research")
+            assert result is not None
+            assert "daily cap" in result.lower()
+
+    def test_per_type_cooldown_blocks(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        _write_session_log(sd, [{"ts": _ts_ago(300), "type": "research"}])
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False), \
+             patch.object(cs, "COOLDOWN_S", 0):  # no global cooldown for this test
+            # research cooldown is 7200s, entry is 300s ago → blocked
+            result = cs.check_budget("research")
+            assert result is not None
+            assert "cooldown" in result.lower()
+
+    def test_per_type_quota_blocks(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        # 4 conversation sessions within last hour = at quota (4/day)
+        entries = [{"ts": _ts_ago(i * 60 + 1000), "type": "conversation"} for i in range(4)]
+        _write_session_log(sd, entries)
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False), \
+             patch.object(cs, "COOLDOWN_S", 0):
+            result = cs.check_budget("conversation")
+            assert result is not None
+            assert "quota" in result.lower()
+
+    def test_corrupt_log_lines_skipped(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        log_file = sd / "claude_sessions.jsonl"
+        # Entry from 3 hours ago — past the 2h research cooldown
+        log_file.write_text('{"ts": "' + _ts_ago(10800) + '", "type": "research"}\nNOT_JSON\n')
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", log_file), \
+             patch.object(cs, "BUDGET_DISABLED", False), \
+             patch.object(cs, "COOLDOWN_S", 0):
+            # Should not crash, and should count the valid entry
+            result = cs.check_budget("research")
+            # Still allowed (1 research, quota is 3, past cooldown)
+            assert result is None
+
+    def test_priority_gating_blocks_low_priority(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        # 6 sessions today with cap=8 → 2 remaining → low priority blocked
+        entries = [{"ts": _ts_ago(i * 100 + 2000), "type": "conversation"} for i in range(6)]
+        _write_session_log(sd, entries)
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False), \
+             patch.object(cs, "DAILY_CAP", 8), \
+             patch.object(cs, "COOLDOWN_S", 0):
+            # compose is low priority (1) — should be blocked
+            result = cs.check_budget("compose")
+            assert result is not None
+            assert "priority" in result.lower()
+
+    def test_priority_gating_allows_high_priority(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        # 6 sessions today with cap=8 → 2 remaining
+        entries = [{"ts": _ts_ago(i * 100 + 2000), "type": "conversation"} for i in range(6)]
+        _write_session_log(sd, entries)
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False), \
+             patch.object(cs, "DAILY_CAP", 8), \
+             patch.object(cs, "COOLDOWN_S", 0):
+            # self_debug is high priority (5) — should be allowed
+            assert cs.check_budget("self_debug") is None
+
+    def test_cold_start_missing_log(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "nonexistent.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", False):
+            assert cs.check_budget("research") is None
+
+    def test_budget_disabled_bypass(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        # Fill up daily cap
+        entries = [{"ts": _ts_ago(i * 100 + 1), "type": "research"} for i in range(10)]
+        _write_session_log(sd, entries)
+        import pxh.claude_session as cs
+        with patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "BUDGET_DISABLED", True):
+            assert cs.check_budget("research") is None
+
+
+# ---------------------------------------------------------------------------
+# Session Execution
+# ---------------------------------------------------------------------------
+
+class TestRunSession:
+    def test_budget_exhausted_raises(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        import pxh.claude_session as cs
+        with patch.object(cs, "check_budget", return_value="test block reason"):
+            with pytest.raises(cs.SessionBudgetExhausted):
+                cs.run_claude_session("research", "test prompt")
+
+    def test_successful_session_logged(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        import pxh.claude_session as cs
+        mock_result = MagicMock()
+        mock_result.stdout = "test output"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch.object(cs, "check_budget", return_value=None), \
+             patch("subprocess.run", return_value=mock_result), \
+             patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "STATE_DIR", sd):
+            result = cs.run_claude_session("research", "test prompt", timeout=10)
+            assert result.stdout == "test output"
+            assert result.returncode == 0
+            assert "haiku" in result.model_used
+
+            # Verify log was written
+            log_file = sd / "claude_sessions.jsonl"
+            assert log_file.exists()
+            entry = json.loads(log_file.read_text().strip())
+            assert entry["type"] == "research"
+            assert entry["outcome"] == "success"
+
+    def test_claude_env_vars_stripped(self, tmp_path):
+        sd = _make_state_dir(tmp_path)
+        import pxh.claude_session as cs
+        captured_env = {}
+
+        def mock_run(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            m = MagicMock()
+            m.stdout = ""
+            m.stderr = ""
+            m.returncode = 0
+            return m
+
+        with patch.object(cs, "check_budget", return_value=None), \
+             patch("subprocess.run", side_effect=mock_run), \
+             patch.object(cs, "SESSION_LOG", sd / "claude_sessions.jsonl"), \
+             patch.object(cs, "STATE_DIR", sd), \
+             patch.dict(os.environ, {"CLAUDECODE": "1", "CLAUDE_CODE_FOO": "bar"}):
+            cs.run_claude_session("research", "test prompt", timeout=10)
+            assert "CLAUDECODE" not in captured_env
+            assert "CLAUDE_CODE_FOO" not in captured_env
+
+
+# ---------------------------------------------------------------------------
+# Whitelist
+# ---------------------------------------------------------------------------
+
+class TestWhitelist:
+    def test_spark_config_allowed(self):
+        from pxh.claude_session import file_in_whitelist
+        assert file_in_whitelist("src/pxh/spark_config.py")
+
+    def test_mind_allowed(self):
+        from pxh.claude_session import file_in_whitelist
+        assert file_in_whitelist("src/pxh/mind.py")
+
+    def test_voice_loop_allowed(self):
+        from pxh.claude_session import file_in_whitelist
+        assert file_in_whitelist("src/pxh/voice_loop.py")
+
+    def test_api_blacklisted(self):
+        from pxh.claude_session import file_in_whitelist
+        assert not file_in_whitelist("src/pxh/api.py")
+
+    def test_px_evolve_blacklisted(self):
+        from pxh.claude_session import file_in_whitelist
+        assert not file_in_whitelist("bin/px-evolve")
+
+    def test_new_tool_allowed(self):
+        from pxh.claude_session import file_in_whitelist
+        assert file_in_whitelist("bin/tool-newfeature")
+
+    def test_test_file_allowed(self):
+        from pxh.claude_session import file_in_whitelist
+        assert file_in_whitelist("tests/test_new.py")
+
+    def test_env_blacklisted(self):
+        from pxh.claude_session import file_in_whitelist
+        assert not file_in_whitelist(".env")
+
+    def test_persona_prompt_blacklisted(self):
+        from pxh.claude_session import file_in_whitelist
+        assert not file_in_whitelist("docs/prompts/persona-gremlin.md")
+        assert not file_in_whitelist("docs/prompts/persona-vixen.md")
+
+    def test_systemd_blacklisted(self):
+        from pxh.claude_session import file_in_whitelist
+        assert not file_in_whitelist("systemd/px-evolve.service")
+
+    def test_prompt_docs_allowed(self):
+        from pxh.claude_session import file_in_whitelist
+        assert file_in_whitelist("docs/prompts/new-prompt.md")
+
+    def test_tool_chat_blacklisted(self):
+        from pxh.claude_session import file_in_whitelist
+        assert not file_in_whitelist("bin/tool-chat")
+        assert not file_in_whitelist("bin/tool-chat-vixen")
+
+
+# ---------------------------------------------------------------------------
+# Self-Debug Trigger (Task 5 prep)
+# ---------------------------------------------------------------------------
+
+class TestSelfDebugTrigger:
+    """Verify self_debug is properly configured in mind.py action sets."""
+
+    def test_self_debug_model_is_sonnet(self):
+        from pxh.claude_session import _model_for_type
+        assert "sonnet" in _model_for_type("self_debug")
+
+    def test_self_debug_exempt_from_global_cooldown(self):
+        from pxh.claude_session import _GLOBAL_COOLDOWN_EXEMPT
+        assert "self_debug" in _GLOBAL_COOLDOWN_EXEMPT
+
+    def test_self_debug_has_highest_priority(self):
+        from pxh.claude_session import _PRIORITY
+        assert _PRIORITY["self_debug"] == max(_PRIORITY.values())
+
+
+# ---------------------------------------------------------------------------
+# Conversation Depth Trigger (Task 6 prep)
+# ---------------------------------------------------------------------------
+
+class TestConversationDepthTrigger:
+    """Test depth trigger phrase detection — implemented in voice_loop.py."""
+
+    def test_think_deeper_triggers(self):
+        from pxh.voice_loop import is_depth_trigger
+        assert is_depth_trigger("think about that more")
+
+    def test_go_deeper_triggers(self):
+        from pxh.voice_loop import is_depth_trigger
+        assert is_depth_trigger("go deeper on that")
+
+    def test_explain_properly_triggers(self):
+        from pxh.voice_loop import is_depth_trigger
+        assert is_depth_trigger("explain that properly")
+
+    def test_normal_text_does_not_trigger(self):
+        from pxh.voice_loop import is_depth_trigger
+        assert not is_depth_trigger("hello there")
+
+    def test_case_insensitive(self):
+        from pxh.voice_loop import is_depth_trigger
+        assert is_depth_trigger("THINK ABOUT THAT MORE")

--- a/tests/test_mind_utils.py
+++ b/tests/test_mind_utils.py
@@ -620,13 +620,14 @@ def test_can_explore_corrupt_meta_fails_safe(explore_state):
 
 
 def test_valid_actions_includes_new_actions():
-    """All 17 actions must be present in VALID_ACTIONS."""
+    """All 20 actions must be present in VALID_ACTIONS."""
     expected = {
         "wait", "greet", "comment", "remember", "look_at",
         "weather_comment", "scan", "explore",
         "play_sound", "photograph", "emote", "look_around",
         "time_check", "calendar_check", "morning_fact",
         "introspect", "evolve",
+        "research", "compose", "self_debug",
     }
     assert VALID_ACTIONS == expected
 
@@ -719,8 +720,8 @@ def test_explore_injection_after_enum_expansion():
     }
 
     # The injection target is the LAST action before the closing quote
-    inject_target = 'morning_fact"'
-    inject_result = 'morning_fact, explore"'
+    inject_target = 'self_debug"'
+    inject_result = 'self_debug, explore"'
 
     for name, prompt in prompts.items():
         # Simulate the injection that reflection() does

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1034,3 +1034,29 @@ def test_tool_photograph_camera_busy(isolated_project):
     data = parse_json(result.stdout.strip())
     assert data["status"] == "error"
     assert "camera busy" in data["error"]
+
+
+def test_tool_research_dry_run(isolated_project):
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"
+    env["PX_RESEARCH_QUERY"] = "Why do magnets work?"
+    result = subprocess.run(
+        [str(PROJECT_ROOT / "bin" / "tool-research")],
+        capture_output=True, text=True, env=env, timeout=10,
+    )
+    data = parse_json(result.stdout)
+    assert data["status"] == "ok"
+    assert data["dry"] is True
+
+
+def test_tool_compose_dry_run(isolated_project):
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"
+    env["PX_COMPOSE_TOPIC"] = "morning light"
+    result = subprocess.run(
+        [str(PROJECT_ROOT / "bin" / "tool-compose")],
+        capture_output=True, text=True, env=env, timeout=10,
+    )
+    data = parse_json(result.stdout)
+    assert data["status"] == "ok"
+    assert data["dry"] is True


### PR DESCRIPTION
## Summary

- **New `src/pxh/claude_session.py`** — central dispatcher for all SPARK-initiated Claude sessions with model routing (Opus/Sonnet/Haiku), rate limiting (8/day cap, per-type cooldowns/quotas, priority gating), and file whitelist enforcement
- **Rewritten `bin/px-evolve`** — replaces blind unified-diff approach (0/9 success rate) with real `Read/Write/Edit/Glob/Grep` tool access via session manager. Claude edits files directly; px-evolve commits after. Bash intentionally excluded for security.
- **New tools**: `tool-research` (Haiku curiosity deep dives), `tool-compose` (Haiku creative writing)
- **New expression actions**: `research`, `compose`, `self_debug` added to mind.py (20 total actions). Self-debug triggers on consecutive reflection failures with Sonnet + read-only tools
- **Conversation depth**: voice loop detects "think deeper"/"go deeper" phrases and routes to Sonnet
- **Integration**: Claude budget in px-statusline (`🧠0/8`), `/public/status` API, and tool-introspect (session stats + evolve PR outcomes)
- **Docs**: CLAUDE.md, all 4 voice/persona prompts, .gitignore updated

## Test Plan

- [x] 595 tests pass (43 new), 0 failures, 0 regressions
- [x] `tool-research` and `tool-compose` dry-run verified
- [x] px-statusline shows `🧠0/8` budget field
- [x] All existing evolve/introspect/mind tests pass
- [ ] Live test: restart px-evolve service and trigger an evolution to verify real tool access works
- [ ] Live test: verify px-mind picks `research`/`compose` actions from reflection

🤖 Generated with [Claude Code](https://claude.com/claude-code)