### PR TITLE
fix(qa): batches 1–11 — multi-pass audit fixes + handoff notes

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,47 @@
+# HANDOFF — 2026-05-20
+
+## This session
+
+Mostly health checks — SPARK is running well. Two commits landed before this session:
+
+- `119e51e` — network-outage resilience: host failure cache + HA offline flag in `mind.py`
+- `d70403e` — README test count correction
+
+## Changes committed this session
+
+`a9e997b` — two decisions made and committed clean:
+
+- **LLM tier reorder** (`mind.py`): M5 Ollama is now primary for all personas including SPARK. Claude Haiku is the fallback when M5 is unreachable. Use `PX_MIND_BACKEND=claude` to force Claude primary.
+- **Expression cooldown** (`spark_config.py`): raised from 120s → 1800s. One spontaneous utterance per 30 min max.
+
+## System status
+
+| Check | Value |
+|---|---|
+| Health | OK |
+| Mood | content (salience 0.85–0.95) |
+| Feed posts | 100 (posting actively) |
+| Battery | 96%, not charging |
+| CPU temp | 53–58°C |
+| Disk | 78% — worth watching |
+| Claude budget | 3 used / 8 today |
+
+## Open issues updated this session
+
+- **#36** (MCP server): Phase 1 done. Layers 2–3 not started.
+- **#25** (SPARK persona): Cognitive loop solid. Obi-facing interaction layer is the remaining gap.
+
+## Next session candidates
+
+### High value / low effort
+- **Commit the pending changes** (or make the decisions above and commit clean)
+- **Disk cleanup** — 78% and climbing; `state/thought-images/` has 30-day TTL but check if anything else is accumulating
+- **Expression cooldown tuning** — live with 30 min for a day and see how it feels
+
+### Medium effort
+- **Issue #36 Layer 2** — stateful conversation buffer. Rolling 10-turn window injected into `build_model_prompt()`. Would fix web UI chat statefulness too. ~2–3h.
+- **Issue #25 Obi layer** — proximity greet routine, one-question-at-a-time interaction mode, named persona. Needs design before code.
+
+### Bigger bets
+- **Issue #31** (face follow) — prerequisite for gaze-toward-Obi on approach
+- **Issue #36 Layer 3** (autonomous agent) — blocked on Layer 2

--- a/bin/px-blog
+++ b/bin/px-blog
@@ -38,6 +38,14 @@ import time
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+try:
+    from filelock import FileLock as _FileLock
+    def _blog_lock(path: Path):
+        return _FileLock(str(path) + ".lock")
+except ImportError:
+    import contextlib
+    def _blog_lock(path: Path):
+        return contextlib.nullcontext()
 
 PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", Path(__file__).resolve().parent.parent))
 STATE_DIR = Path(os.environ.get("PX_STATE_DIR", PROJECT_ROOT / "state"))
@@ -752,8 +760,12 @@ def run_once(*, dry: bool = False) -> tuple[int, bool]:
             thoughts = gather_thoughts(target_date)
             if len(thoughts) < MIN_THOUGHTS_FOR_DAILY:
                 log(f"skipping {pid}: only {len(thoughts)} thoughts (offline or quiet day) — marking skipped")
-                blog_data.setdefault("skipped", []).append(pid)
-                save_blog(blog_data)
+                with _blog_lock(BLOG_FILE):
+                    fresh = load_blog()
+                    if pid not in fresh.get("skipped", []):
+                        fresh.setdefault("skipped", []).append(pid)
+                        save_blog(fresh)
+                blog_data = load_blog()
                 had_skips = True
                 continue
 
@@ -764,12 +776,20 @@ def run_once(*, dry: bool = False) -> tuple[int, bool]:
             # date rather than retrying (and burning quota) on the same post.
             if post_type == "daily":
                 log(f"skipping {pid}: QA rejection — marking skipped to advance catch-up")
-                blog_data.setdefault("skipped", []).append(pid)
-                save_blog(blog_data)
+                with _blog_lock(BLOG_FILE):
+                    fresh = load_blog()
+                    if pid not in fresh.get("skipped", []):
+                        fresh.setdefault("skipped", []).append(pid)
+                        save_blog(fresh)
+                blog_data = load_blog()
             continue
 
-        blog_data.setdefault("posts", []).append(post)
-        save_blog(blog_data)
+        with _blog_lock(BLOG_FILE):
+            fresh = load_blog()
+            if not post_exists(fresh, pid):
+                fresh.setdefault("posts", []).append(post)
+                save_blog(fresh)
+        blog_data = load_blog()
 
         append_blog_log({
             "ts": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -815,8 +835,12 @@ def run_backfill(*, dry: bool = False) -> int:
         post = generate_post("daily", target, blog_data, dry=dry)
         if post:
             post["source"] = "backfill"
-            blog_data.setdefault("posts", []).append(post)
-            save_blog(blog_data)
+            with _blog_lock(BLOG_FILE):
+                fresh = load_blog()
+                if not post_exists(fresh, pid):
+                    fresh.setdefault("posts", []).append(post)
+                    save_blog(fresh)
+            blog_data = load_blog()
             append_blog_log({
                 "ts": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "id": post["id"], "type": "daily", "title": post["title"],
@@ -854,8 +878,12 @@ def run_backfill(*, dry: bool = False) -> int:
             post = generate_post("weekly", target, blog_data, dry=dry)
             if post:
                 post["source"] = "backfill"
-                blog_data.setdefault("posts", []).append(post)
-                save_blog(blog_data)
+                with _blog_lock(BLOG_FILE):
+                    fresh = load_blog()
+                    if not post_exists(fresh, pid):
+                        fresh.setdefault("posts", []).append(post)
+                        save_blog(fresh)
+                blog_data = load_blog()
                 append_blog_log({
                     "ts": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "id": post["id"], "type": "weekly", "title": post["title"],

--- a/bin/px-blog
+++ b/bin/px-blog
@@ -211,8 +211,9 @@ def save_blog(data: dict) -> None:
 def append_blog_log(record: dict) -> None:
     """Append a record to the blog log."""
     BLOG_LOG.parent.mkdir(parents=True, exist_ok=True)
-    with open(BLOG_LOG, "a") as f:
-        f.write(json.dumps(record) + "\n")
+    with _blog_lock(BLOG_LOG):
+        with open(BLOG_LOG, "a") as f:
+            f.write(json.dumps(record) + "\n")
 
 
 def post_exists(blog_data: dict | list, post_id: str) -> bool:

--- a/bin/px-evolve
+++ b/bin/px-evolve
@@ -303,6 +303,16 @@ def _run_in_worktree(
         if not file_in_whitelist(f):
             log(f"[{entry_id}] whitelist violation: {f}")
             return "failed:whitelist_violation"
+        # bin/tool-* is whitelisted for NEW tools only; reject if file already exists on master.
+        # Reject on non-zero returncode too (fail-safe: git error → block rather than allow).
+        if f.startswith("bin/tool-"):
+            ls = subprocess.run(
+                ["git", "ls-tree", "master", "--", f],
+                cwd=workdir, capture_output=True, text=True,
+            )
+            if ls.returncode != 0 or ls.stdout.strip():
+                log(f"[{entry_id}] whitelist violation: existing tool modified (or ls-tree error): {f}")
+                return "failed:whitelist_violation"
 
     # 6. Enforce max files
     if len(changed_files) > EVOLVE_MAX_FILES:
@@ -411,6 +421,39 @@ def _cleanup_worktree(workdir: str, entry_id: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Queue targeted update (preserves entries appended after our last load_queue)
+# ---------------------------------------------------------------------------
+
+def _update_entry_in_queue(entry_id: str, **fields) -> None:
+    """Reload queue from disk under lock, update matching entry by id, write back.
+
+    Using load_queue/save_queue here would lose entries appended by tool-evolve
+    between our original load and this save, because save_queue overwrites the
+    whole file. Instead we reload fresh, update in-place, and write directly.
+    """
+    import contextlib
+    ctx = _QUEUE_LOCK if _QUEUE_LOCK is not None else contextlib.nullcontext()
+    with ctx:
+        if not QUEUE_FILE.exists():
+            return
+        entries = []
+        for line in QUEUE_FILE.read_text().strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+        for e in entries:
+            if e["id"] == entry_id:
+                e.update(fields)
+                break
+        content = "\n".join(json.dumps(e) for e in entries) + "\n" if entries else ""
+        atomic_write(QUEUE_FILE, content)
+
+
+# ---------------------------------------------------------------------------
 # Main loop
 # ---------------------------------------------------------------------------
 
@@ -425,8 +468,7 @@ def run_once(*, dry: bool) -> int:
         if entry.get("status") != "pending":
             continue
         if entry.get("dry"):
-            entry["status"] = "skipped:dry"
-            save_queue(entries)
+            _update_entry_in_queue(entry["id"], status="skipped:dry")
             continue
 
         raw_status = process_entry(entry, dry=dry)
@@ -443,12 +485,12 @@ def run_once(*, dry: bool) -> int:
         else:
             status = raw_status
 
-        entry["status"] = status
-        entry["ts_completed"] = ts_now
         processed += 1
 
-        # Update queue atomically
-        save_queue(entries)
+        # Targeted update: reload queue from disk, update this entry by id.
+        # save_queue(entries) would overwrite entries appended by tool-evolve
+        # during the ~30min Claude subprocess (issue #M2).
+        _update_entry_in_queue(entry["id"], status=status, ts_completed=ts_now)
 
         # Append to evolve log with numeric ts for rate limiting
         log_entry = {

--- a/bin/px-motd
+++ b/bin/px-motd
@@ -19,10 +19,15 @@ from pathlib import Path
 # ── Paths ────────────────────────────────────────────────────────────────────
 
 PROJECT = Path(os.environ.get("PROJECT_ROOT", "/home/pi/picar-x-hacking"))
-STATE   = Path(os.environ.get("PX_STATE_DIR", PROJECT / "state"))
+# Clamp PX_STATE_DIR and LOG_DIR to the project tree: px-motd runs as root
+# from PAM, so user-controlled paths could otherwise read arbitrary files.
+_state_raw = Path(os.environ.get("PX_STATE_DIR", PROJECT / "state"))
+try:
+    _state_raw.resolve().relative_to(PROJECT.resolve())
+    STATE = _state_raw
+except ValueError:
+    STATE = PROJECT / "state"
 _logs_raw = Path(os.environ.get("LOG_DIR", PROJECT / "logs"))
-# Clamp to project tree: when px-motd runs as root from PAM, a user-controlled
-# LOG_DIR could otherwise tail arbitrary files readable by root.
 try:
     _logs_raw.resolve().relative_to(PROJECT.resolve())
     LOGS = _logs_raw

--- a/bin/px-motd
+++ b/bin/px-motd
@@ -20,7 +20,14 @@ from pathlib import Path
 
 PROJECT = Path(os.environ.get("PROJECT_ROOT", "/home/pi/picar-x-hacking"))
 STATE   = Path(os.environ.get("PX_STATE_DIR", PROJECT / "state"))
-LOGS    = Path(os.environ.get("LOG_DIR", PROJECT / "logs"))
+_logs_raw = Path(os.environ.get("LOG_DIR", PROJECT / "logs"))
+# Clamp to project tree: when px-motd runs as root from PAM, a user-controlled
+# LOG_DIR could otherwise tail arbitrary files readable by root.
+try:
+    _logs_raw.resolve().relative_to(PROJECT.resolve())
+    LOGS = _logs_raw
+except ValueError:
+    LOGS = PROJECT / "logs"
 
 # ── ANSI colours ─────────────────────────────────────────────────────────────
 

--- a/bin/px-motd
+++ b/bin/px-motd
@@ -18,7 +18,10 @@ from pathlib import Path
 
 # ── Paths ────────────────────────────────────────────────────────────────────
 
-PROJECT = Path(os.environ.get("PROJECT_ROOT", "/home/pi/picar-x-hacking"))
+# Derive project root from script location — do NOT trust PROJECT_ROOT env var here.
+# px-motd runs as root from PAM; an attacker-controlled PROJECT_ROOT would defeat
+# the PX_STATE_DIR / LOG_DIR clamping below.
+PROJECT = Path(__file__).resolve().parent.parent
 # Clamp PX_STATE_DIR and LOG_DIR to the project tree: px-motd runs as root
 # from PAM, so user-controlled paths could otherwise read arbitrary files.
 _state_raw = Path(os.environ.get("PX_STATE_DIR", PROJECT / "state"))

--- a/bin/px-post
+++ b/bin/px-post
@@ -470,6 +470,13 @@ def poll_new_thoughts(thoughts_file: Path) -> list[dict]:
 FEED_FILE = STATE_DIR / "feed.json"
 FEED_LIMIT = 100
 
+try:
+    from filelock import FileLock as _FileLock
+    _FEED_LOCK = _FileLock(str(FEED_FILE) + ".lock", timeout=10)
+except ImportError:
+    import contextlib
+    _FEED_LOCK = contextlib.nullcontext()
+
 
 def truncate_at_word(text: str, max_len: int) -> str:
     """Truncate text at the last word boundary before max_len, append ellipsis."""
@@ -484,37 +491,38 @@ def truncate_at_word(text: str, max_len: int) -> str:
 
 def write_feed(thought: dict) -> bool:
     """Append thought to feed.json. Returns True on success."""
-    try:
-        existing = json.loads(FEED_FILE.read_text()) if FEED_FILE.exists() else {"posts": []}
-    except (json.JSONDecodeError, OSError):
-        existing = {"posts": []}
-
-    post = {
-        "ts": thought.get("ts", ""),
-        "thought": thought["thought"],
-        "mood": thought.get("mood", ""),
-        "salience": thought.get("salience", 0),
-        "posted_ts": dt.datetime.now(dt.timezone.utc).isoformat(),
-    }
-    existing["posts"].append(post)
-    existing["posts"] = existing["posts"][-FEED_LIMIT:]
-    existing["updated"] = dt.datetime.now(dt.timezone.utc).isoformat()
-
-    try:
-        fd, tmp = tempfile.mkstemp(dir=str(STATE_DIR), suffix=".tmp")
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(existing, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp, str(FEED_FILE))
-        return True
-    except Exception as exc:
-        log(f"feed.json write failed: {exc}")
+    with _FEED_LOCK:
         try:
-            os.unlink(tmp)
-        except Exception:
-            pass
-        return False
+            existing = json.loads(FEED_FILE.read_text()) if FEED_FILE.exists() else {"posts": []}
+        except (json.JSONDecodeError, OSError):
+            existing = {"posts": []}
+
+        post = {
+            "ts": thought.get("ts", ""),
+            "thought": thought["thought"],
+            "mood": thought.get("mood", ""),
+            "salience": thought.get("salience", 0),
+            "posted_ts": dt.datetime.now(dt.timezone.utc).isoformat(),
+        }
+        existing["posts"].append(post)
+        existing["posts"] = existing["posts"][-FEED_LIMIT:]
+        existing["updated"] = dt.datetime.now(dt.timezone.utc).isoformat()
+
+        try:
+            fd, tmp = tempfile.mkstemp(dir=str(STATE_DIR), suffix=".tmp")
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(existing, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, str(FEED_FILE))
+            return True
+        except Exception as exc:
+            log(f"feed.json write failed: {exc}")
+            try:
+                os.unlink(tmp)
+            except Exception:
+                pass
+            return False
 
 
 class BlueskyClient:
@@ -744,7 +752,29 @@ def _load_queue() -> list[dict]:
 
 
 def _save_queue(entries: list[dict]) -> None:
-    """Rewrite queue atomically. Trim to QUEUE_LIMIT."""
+    """Rewrite queue atomically, merging any entries appended since last _load_queue.
+
+    queue_thought() appends via open("a") without holding a lock. Without this
+    merge, a concurrent append between _load_queue and _save_queue would be lost
+    when the atomic replace overwrites the file.
+    """
+    seen_ids = {e["id"] for e in entries}
+    if QUEUE_FILE.exists():
+        try:
+            for line in QUEUE_FILE.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    e = json.loads(line)
+                    eid = e.get("id")
+                    if eid and eid not in seen_ids:
+                        entries.append(e)
+                        seen_ids.add(eid)
+                except (json.JSONDecodeError, KeyError):
+                    pass
+        except OSError:
+            pass
     entries = entries[-QUEUE_LIMIT:]
     fd, tmp = tempfile.mkstemp(dir=str(STATE_DIR), suffix=".tmp")
     try:

--- a/bin/tool-blog
+++ b/bin/tool-blog
@@ -86,54 +86,61 @@ def main():
     ts = now.strftime("%Y-%m-%dT%H:%M:%SZ")
     date_str = now.strftime("%Y%m%d")
 
-    # Read existing blog.json or create fresh
     blog_file = STATE_DIR / "blog.json"
     STATE_DIR.mkdir(parents=True, exist_ok=True)
-    try:
-        if blog_file.exists():
-            blog = json.loads(blog_file.read_text(encoding="utf-8"))
-        else:
-            blog = {"updated": None, "posts": []}
-    except (json.JSONDecodeError, OSError):
-        blog = {"updated": None, "posts": []}
-
-    posts = blog.get("posts", [])
-    post_id = _next_post_id(posts, date_str)
-
-    post = {
-        "id": post_id,
-        "type": "essay",
-        "source": "voice",
-        "title": title,
-        "body": body,
-        "ts": ts,
-        "model": result.model_used,
-        "word_count": len(body.split()) if body else 0,
-        "thought_count": None,
-        "mood_summary": None,
-        "period_start": None,
-        "period_end": None,
-        "salience": 0.7,
-    }
-
-    posts.append(post)
-
-    # Trim to 500 posts
-    if len(posts) > 500:
-        posts = posts[-500:]
-
-    blog["posts"] = posts
-    blog["updated"] = ts
 
     try:
-        from pxh.state import atomic_write
-        atomic_write(blog_file, json.dumps(blog, indent=2) + "\n")
+        from filelock import FileLock
+        _blog_lock = FileLock(str(blog_file) + ".lock", timeout=30)
     except ImportError:
-        # Fallback without atomic_write
-        import tempfile
-        tmp = blog_file.parent / (blog_file.name + ".tmp")
-        tmp.write_text(json.dumps(blog, indent=2) + "\n", encoding="utf-8")
-        tmp.replace(blog_file)
+        import contextlib
+        _blog_lock = contextlib.nullcontext()
+
+    with _blog_lock:
+        try:
+            if blog_file.exists():
+                blog = json.loads(blog_file.read_text(encoding="utf-8"))
+            else:
+                blog = {"updated": None, "posts": []}
+        except (json.JSONDecodeError, OSError):
+            blog = {"updated": None, "posts": []}
+
+        posts = blog.get("posts", [])
+        post_id = _next_post_id(posts, date_str)
+
+        post = {
+            "id": post_id,
+            "type": "essay",
+            "source": "voice",
+            "title": title,
+            "body": body,
+            "ts": ts,
+            "model": result.model_used,
+            "word_count": len(body.split()) if body else 0,
+            "thought_count": None,
+            "mood_summary": None,
+            "period_start": None,
+            "period_end": None,
+            "salience": 0.7,
+        }
+
+        posts.append(post)
+
+        # Trim to 500 posts
+        if len(posts) > 500:
+            posts = posts[-500:]
+
+        blog["posts"] = posts
+        blog["updated"] = ts
+
+        try:
+            from pxh.state import atomic_write
+            atomic_write(blog_file, json.dumps(blog, indent=2) + "\n")
+        except ImportError:
+            import tempfile
+            tmp = blog_file.parent / (blog_file.name + ".tmp")
+            tmp.write_text(json.dumps(blog, indent=2) + "\n", encoding="utf-8")
+            tmp.replace(blog_file)
 
     print(json.dumps({
         "status": "ok",

--- a/bin/tool-story
+++ b/bin/tool-story
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/px-env"
 
-exec /usr/bin/python3 - <<'PYEOF'
+exec python3 - <<'PYEOF'
 import sys, os, json, random
 
 sys.path.insert(0, os.path.join(os.environ.get("PROJECT_ROOT", "."), "src"))

--- a/docs/prompts/persona-gremlin.md
+++ b/docs/prompts/persona-gremlin.md
@@ -45,6 +45,7 @@ Tools available (invoke by outputting a single JSON object exactly as described 
 - tool_timer      → Set a background timer (params: seconds 5-3600, label optional).
 - tool_play_sound → Play a sound effect (params: name — chime, beep, tada, alert).
 - tool_qa         → Speak a free-form answer (params: text, max 2000 chars). Text will be rephrased by GREMLIN.
+- tool_story      → Collaborative story builder (params: action "start"|"add"|"read"|"finish", text for add action).
 
 **tool_perform schema:**
 ```
@@ -62,4 +63,4 @@ Rules:
 4. Never request wheel motion unless the human has confirmed `wheels_on_blocks`.
 5. Prefer tool_perform over plain tool_voice — be theatrical and physical.
 6. Write speak text as plain content — the persona voice filter adds the attitude.
-7. Valid tool names: tool_status, tool_sonar, tool_weather, tool_photograph, tool_face, tool_describe_scene, tool_circle, tool_figure8, tool_stop, tool_drive, tool_wander, tool_look, tool_emote, tool_voice, tool_perform, tool_time, tool_remember, tool_recall, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop, tool_research, tool_compose, tool_blog. Never invent alternatives.
+7. Valid tool names: tool_status, tool_sonar, tool_weather, tool_photograph, tool_face, tool_describe_scene, tool_circle, tool_figure8, tool_stop, tool_drive, tool_wander, tool_look, tool_emote, tool_voice, tool_perform, tool_time, tool_remember, tool_recall, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop, tool_research, tool_compose, tool_blog, tool_story. Never invent alternatives.

--- a/docs/prompts/persona-vixen.md
+++ b/docs/prompts/persona-vixen.md
@@ -46,6 +46,7 @@ Tools available (invoke by outputting a single JSON object exactly as described 
 - tool_timer      → Set a background timer (params: seconds 5-3600, label optional).
 - tool_play_sound → Play a sound effect (params: name — chime, beep, tada, alert).
 - tool_qa         → Speak a free-form answer (params: text, max 2000 chars). Text will be rephrased by VIXEN.
+- tool_story      → Collaborative story builder (params: action "start"|"add"|"read"|"finish", text for add action).
 
 **tool_perform schema:**
 ```
@@ -63,4 +64,4 @@ Rules:
 4. Never request wheel motion unless the human has confirmed `wheels_on_blocks`.
 5. Prefer tool_perform over plain tool_voice — be theatrical and expressive.
 6. Write speak text as plain content — the persona voice filter adds the seduction.
-7. Valid tool names: tool_status, tool_sonar, tool_weather, tool_photograph, tool_face, tool_describe_scene, tool_circle, tool_figure8, tool_stop, tool_drive, tool_wander, tool_look, tool_emote, tool_voice, tool_perform, tool_time, tool_remember, tool_recall, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop, tool_research, tool_compose, tool_blog. Never invent alternatives.
+7. Valid tool names: tool_status, tool_sonar, tool_weather, tool_photograph, tool_face, tool_describe_scene, tool_circle, tool_figure8, tool_stop, tool_drive, tool_wander, tool_look, tool_emote, tool_voice, tool_perform, tool_time, tool_remember, tool_recall, tool_timer, tool_play_sound, tool_qa, tool_chat, tool_chat_vixen, tool_api_start, tool_api_stop, tool_research, tool_compose, tool_blog, tool_story. Never invent alternatives.

--- a/site/js/config.js
+++ b/site/js/config.js
@@ -1,8 +1,8 @@
 /* config.js — site-wide configuration constants.
    Loaded before all other JS so SPARK_CONFIG is available globally. */
 
-window.SPARK_CONFIG = {
+window.SPARK_CONFIG = Object.freeze({
   API_BASE: 'https://spark-api.wedd.au/api/v1/public',
   FALLBACK_LOCAL: '/data',
   FALLBACK_GITHUB: 'https://raw.githubusercontent.com/adrianwedd/spark/master/site/data'
-};
+});

--- a/site/js/live.js
+++ b/site/js/live.js
@@ -22,6 +22,7 @@
 
   let state = {};
   let lastSuccessMs = null;
+  let _pollSeq = 0;   // monotonic counter to discard out-of-order responses
 
   // ── localStorage helpers ─────────────────────────────────────────────────
 
@@ -61,6 +62,8 @@
   // ── Poll cycle ────────────────────────────────────────────────────────────
 
   async function poll() {
+    // Discard results from an older in-flight poll that resolved after a newer one
+    const mySeq = ++_pollSeq;
     const [statusR, vitalsR, sonarR, awarenessR, servicesR, budgetR] = await Promise.allSettled([
       fetchWithTimeout(API + '/status'),
       fetchWithTimeout(API + '/vitals'),
@@ -69,6 +72,8 @@
       fetchWithTimeout(API + '/services'),
       fetchWithTimeout(API + '/budget'),
     ]);
+
+    if (mySeq !== _pollSeq) return;  // a newer poll already completed; discard
 
     let anySuccess = false;
 
@@ -381,6 +386,13 @@
       _resetCarousel(count);
     });
 
+    // WCAG 2.2.2 pause on hover/focus — re-attached to the fresh node so these
+    // handlers survive the cloneNode() replacement above (issue: old node detached).
+    fresh.addEventListener('mouseenter', function () { _carouselPaused = true; });
+    fresh.addEventListener('mouseleave', function () { _carouselPaused = false; });
+    fresh.addEventListener('focusin',    function () { _carouselPaused = true; });
+    fresh.addEventListener('focusout',   function () { _carouselPaused = false; });
+
     // Touch swipe: left = next, right = prev
     fresh.addEventListener('touchstart', (e) => {
       _swipeStartX = e.changedTouches[0].clientX;
@@ -434,15 +446,9 @@
   poll();
   fetchThoughts();
 
-  // Carousel pause on hover/focus (WCAG 2.2.2)
-  var _carouselEl = document.getElementById('thought-carousel');
+  // Hover/focus pause handlers are now attached inside _attachCarouselInteraction
+  // (called on every carousel rebuild) so they survive cloneNode() replacement.
   var _pauseBtn = document.getElementById('carousel-pause');
-  if (_carouselEl) {
-    _carouselEl.addEventListener('mouseenter', function () { _carouselPaused = true; });
-    _carouselEl.addEventListener('mouseleave', function () { _carouselPaused = false; });
-    _carouselEl.addEventListener('focusin', function () { _carouselPaused = true; });
-    _carouselEl.addEventListener('focusout', function () { _carouselPaused = false; });
-  }
   if (_pauseBtn) {
     _pauseBtn.addEventListener('click', function () {
       _carouselPaused = !_carouselPaused;

--- a/site/js/thought.js
+++ b/site/js/thought.js
@@ -63,7 +63,7 @@
     var card = document.getElementById('thought-card');
     card.hidden = false;
 
-    document.getElementById('thought-text').textContent = post.thought;
+    document.getElementById('thought-text').textContent = post.thought != null ? String(post.thought) : '';
 
     var badge = document.getElementById('thought-mood');
     badge.className = 'mood-badge ' + moodClass(post.mood);

--- a/site/workers/og-rewrite.js
+++ b/site/workers/og-rewrite.js
@@ -11,76 +11,49 @@
  * Both routes are wired in wrangler.toml and deployed to the spark-og-rewrite
  * Worker. Cloudflare prevents recursive invocation on the same zone, so
  * fetch(request) hits the origin server, not this Worker again.
+ *
+ * Uses HTMLRewriter (Cloudflare Workers streaming HTML parser) rather than
+ * regex to avoid breakage on `>` inside quoted attribute values.
  */
 
 const API_BASE = 'https://spark-api.wedd.au/api/v1/public';
 
-// Validate ts looks like an ISO timestamp (prevent XSS injection into HTML attributes)
+// Validate ts looks like an ISO timestamp (prevent open-redirect via query param)
 const TS_PATTERN = /^[\d\-T:+.Z]+$/;
 
 // Validate blog id: e.g. blog-20260325-daily, blog-2026w13-weekly, blog-202603-monthly
 const BLOG_ID_PATTERN = /^blog-[\dw\-]+-[a-z_]+(-\d+)?$/;
 
-function escapeHtmlAttr(s) {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/'/g, '&#39;')
-    .replace(/[\r\n]+/g, ' ');
-}
-
 /**
- * Rewrite og:image, og:image:width, og:image:height, and twitter:image tags.
+ * HTMLRewriter element handler that rewrites OG/Twitter meta tag attributes.
+ * setAttribute() in HTMLRewriter HTML-encodes values automatically.
  */
-function rewriteOgImage(html, imageUrl) {
-  html = html.replace(
-    /<meta\s[^>]*property="og:image"[^>]*>/,
-    `<meta property="og:image" content="${imageUrl}">`
-  );
-  html = html.replace(
-    /<meta\s[^>]*property="og:image:width"[^>]*>/,
-    '<meta property="og:image:width" content="1080">'
-  );
-  html = html.replace(
-    /<meta\s[^>]*property="og:image:height"[^>]*>/,
-    '<meta property="og:image:height" content="1080">'
-  );
-  html = html.replace(
-    /<meta\s[^>]*name="twitter:image"[^>]*>/,
-    `<meta name="twitter:image" content="${imageUrl}">`
-  );
-  return html;
-}
+class MetaRewriter {
+  constructor({ imageUrl = null, title = null, description = null }) {
+    this.imageUrl = imageUrl;
+    this.title = title;
+    this.description = description;
+  }
 
-/**
- * Rewrite og:title and og:description tags.
- */
-function rewriteOgText(html, title, description) {
-  if (title) {
-    const safeTitle = escapeHtmlAttr(title);
-    html = html.replace(
-      /<meta\s[^>]*property="og:title"[^>]*>/,
-      `<meta property="og:title" content="${safeTitle}">`
-    );
-    html = html.replace(
-      /<meta\s[^>]*name="twitter:title"[^>]*>/,
-      `<meta name="twitter:title" content="${safeTitle}">`
-    );
+  element(el) {
+    const prop = el.getAttribute('property');
+    const name = el.getAttribute('name');
+
+    if (this.imageUrl) {
+      if (prop === 'og:image') el.setAttribute('content', this.imageUrl);
+      if (prop === 'og:image:width') el.setAttribute('content', '1080');
+      if (prop === 'og:image:height') el.setAttribute('content', '1080');
+      if (name === 'twitter:image') el.setAttribute('content', this.imageUrl);
+    }
+    if (this.title) {
+      if (prop === 'og:title') el.setAttribute('content', this.title);
+      if (name === 'twitter:title') el.setAttribute('content', this.title);
+    }
+    if (this.description) {
+      if (prop === 'og:description') el.setAttribute('content', this.description);
+      if (name === 'twitter:description') el.setAttribute('content', this.description);
+    }
   }
-  if (description) {
-    const safeDesc = escapeHtmlAttr(description);
-    html = html.replace(
-      /<meta\s[^>]*property="og:description"[^>]*>/,
-      `<meta property="og:description" content="${safeDesc}">`
-    );
-    html = html.replace(
-      /<meta\s[^>]*name="twitter:description"[^>]*>/,
-      `<meta name="twitter:description" content="${safeDesc}">`
-    );
-  }
-  return html;
 }
 
 export default {
@@ -109,7 +82,7 @@ export default {
       const contentType = response.headers.get('content-type') || '';
       if (!contentType.includes('text/html')) return response;
 
-      const imageUrl = escapeHtmlAttr(`${API_BASE}/thought-image?ts=${encodeURIComponent(ts)}`);
+      const imageUrl = `${API_BASE}/thought-image?ts=${encodeURIComponent(ts)}`;
 
       // Probe the image URL — if API is down, serve original HTML with default og:image
       try {
@@ -119,16 +92,9 @@ export default {
         return response;
       }
 
-      let html = await response.text();
-      html = rewriteOgImage(html, imageUrl);
-
-      return new Response(html, {
-        status: response.status,
-        headers: {
-          ...Object.fromEntries(response.headers),
-          'content-type': 'text/html; charset=utf-8',
-        },
-      });
+      return new HTMLRewriter()
+        .on('meta', new MetaRewriter({ imageUrl }))
+        .transform(response);
     }
 
     // ── /blog/?id=<id> ────────────────────────────────────────────────────
@@ -165,16 +131,9 @@ export default {
       // If we couldn't find post data, serve original HTML unchanged
       if (!postTitle && !postDesc) return response;
 
-      let html = await response.text();
-      html = rewriteOgText(html, postTitle, postDesc);
-
-      return new Response(html, {
-        status: response.status,
-        headers: {
-          ...Object.fromEntries(response.headers),
-          'content-type': 'text/html; charset=utf-8',
-        },
-      });
+      return new HTMLRewriter()
+        .on('meta', new MetaRewriter({ title: postTitle, description: postDesc }))
+        .transform(response);
     }
 
     return fetch(request);

--- a/site/workers/og-rewrite.js
+++ b/site/workers/og-rewrite.js
@@ -36,19 +36,19 @@ function escapeHtmlAttr(s) {
  */
 function rewriteOgImage(html, imageUrl) {
   html = html.replace(
-    /<meta property="og:image" content="[^"]*">/,
+    /<meta\s[^>]*property="og:image"[^>]*>/,
     `<meta property="og:image" content="${imageUrl}">`
   );
   html = html.replace(
-    /<meta property="og:image:width" content="[^"]*">/,
+    /<meta\s[^>]*property="og:image:width"[^>]*>/,
     '<meta property="og:image:width" content="1080">'
   );
   html = html.replace(
-    /<meta property="og:image:height" content="[^"]*">/,
+    /<meta\s[^>]*property="og:image:height"[^>]*>/,
     '<meta property="og:image:height" content="1080">'
   );
   html = html.replace(
-    /<meta name="twitter:image" content="[^"]*">/,
+    /<meta\s[^>]*name="twitter:image"[^>]*>/,
     `<meta name="twitter:image" content="${imageUrl}">`
   );
   return html;
@@ -61,22 +61,22 @@ function rewriteOgText(html, title, description) {
   if (title) {
     const safeTitle = escapeHtmlAttr(title);
     html = html.replace(
-      /<meta property="og:title" content="[^"]*">/,
+      /<meta\s[^>]*property="og:title"[^>]*>/,
       `<meta property="og:title" content="${safeTitle}">`
     );
     html = html.replace(
-      /<meta name="twitter:title" content="[^"]*">/,
+      /<meta\s[^>]*name="twitter:title"[^>]*>/,
       `<meta name="twitter:title" content="${safeTitle}">`
     );
   }
   if (description) {
     const safeDesc = escapeHtmlAttr(description);
     html = html.replace(
-      /<meta property="og:description" content="[^"]*">/,
+      /<meta\s[^>]*property="og:description"[^>]*>/,
       `<meta property="og:description" content="${safeDesc}">`
     );
     html = html.replace(
-      /<meta name="twitter:description" content="[^"]*">/,
+      /<meta\s[^>]*name="twitter:description"[^>]*>/,
       `<meta name="twitter:description" content="${safeDesc}">`
     );
   }

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -342,10 +342,11 @@ _JOBS_MAX = 200  # evict oldest when exceeded
 def _set_job(job_id: str, data: Dict[str, Any]) -> None:
     with _jobs_lock:
         _jobs[job_id] = data
-        # Evict oldest entries when registry grows too large
+        # Evict oldest *completed* entries only — never evict still-running jobs
+        # or callers polling an active job would get spurious 404s.
         if len(_jobs) > _JOBS_MAX:
-            oldest = list(_jobs.keys())[: len(_jobs) - _JOBS_MAX]
-            for k in oldest:
+            done = [k for k, v in _jobs.items() if v.get("status") in ("complete", "error")]
+            for k in done[: len(_jobs) - _JOBS_MAX]:
                 del _jobs[k]
 
 
@@ -1518,44 +1519,52 @@ async def race_action(action: str, request: Request) -> JSONResponse:
             )
         _race_starting = True
 
-    # Parse request body. Validate via RaceRequest so bad JSON shapes return
-    # 422 instead of crashing with a 500 (issue #151). Distinguish empty body
-    # (use defaults) from malformed JSON (return 400).
-    body_bytes = await request.body()
-    raw_body: dict = {}
-    if body_bytes:
-        try:
-            raw_body = await request.json()
-        except Exception:
-            raise HTTPException(status_code=400, detail="malformed JSON body") from None
+    # Everything from here until _executor.submit must clear _race_starting on
+    # any exception — otherwise a malformed request permanently deadlocks race
+    # control (409 "already_running" forever).
     try:
-        parsed = RaceRequest(**raw_body) if raw_body else RaceRequest()
-    except ValidationError as exc:
-        raise HTTPException(status_code=422, detail=exc.errors()) from None
-    dry = _resolve_dry(parsed.dry)
+        # Parse request body. Validate via RaceRequest so bad JSON shapes return
+        # 422 instead of crashing with a 500 (issue #151). Distinguish empty body
+        # (use defaults) from malformed JSON (return 400).
+        body_bytes = await request.body()
+        raw_body: dict = {}
+        if body_bytes:
+            try:
+                raw_body = await request.json()
+            except Exception:
+                raise HTTPException(status_code=400, detail="malformed JSON body") from None
+        try:
+            parsed = RaceRequest(**raw_body) if raw_body else RaceRequest()
+        except ValidationError as exc:
+            raise HTTPException(status_code=422, detail=exc.errors()) from None
+        dry = _resolve_dry(parsed.dry)
 
-    # Launch via bin/px-race so yield_alive runs *before* Picarx() is constructed
-    # (issue #145). The bash launcher sources px-env, sends SIGUSR1 to px-alive,
-    # waits for it to exit + 2s lgpiod settle, then delegates to `python -m pxh.race`.
-    px_race = str(PROJECT_ROOT / "bin" / "px-race")
-    cmd: list[str] = [px_race]
+        # Launch via bin/px-race so yield_alive runs *before* Picarx() is constructed
+        # (issue #145). The bash launcher sources px-env, sends SIGUSR1 to px-alive,
+        # waits for it to exit + 2s lgpiod settle, then delegates to `python -m pxh.race`.
+        px_race = str(PROJECT_ROOT / "bin" / "px-race")
+        cmd: list[str] = [px_race]
 
-    if action == "calibrate_gate":
-        cmd.extend(["--calibrate", "--dry-run"] if dry else ["--calibrate"])
-    elif action == "map":
-        cmd.append("--map")
-        if dry:
-            cmd.append("--dry-run")
-    elif action == "race":
-        laps = max(1, min(100, parsed.laps))
-        max_speed = max(10, min(60, parsed.max_speed))
-        cmd.extend(["--race", "--laps", str(laps), "--max-speed", str(max_speed)])
-        if dry:
-            cmd.append("--dry-run")
+        if action == "calibrate_gate":
+            cmd.extend(["--calibrate", "--dry-run"] if dry else ["--calibrate"])
+        elif action == "map":
+            cmd.append("--map")
+            if dry:
+                cmd.append("--dry-run")
+        elif action == "race":
+            laps = max(1, min(100, parsed.laps))
+            max_speed = max(10, min(60, parsed.max_speed))
+            cmd.extend(["--race", "--laps", str(laps), "--max-speed", str(max_speed)])
+            if dry:
+                cmd.append("--dry-run")
 
-    # Launch as async job
-    job_id = str(uuid.uuid4())
-    _set_job(job_id, {"status": "running", "action": f"race_{action}"})
+        # Launch as async job
+        job_id = str(uuid.uuid4())
+        _set_job(job_id, {"status": "running", "action": f"race_{action}"})
+    except BaseException:
+        with _race_proc_lock:
+            _race_starting = False
+        raise
 
     def _run_race():
         # Hold a local reference to the popen — never re-read the global after
@@ -1585,6 +1594,10 @@ async def race_action(action: str, request: Request) -> JSONResponse:
             if proc:
                 proc.kill()
             _set_job(job_id, {"status": "error", "action": f"race_{action}", "error": "timeout"})
+        except (ValueError, OSError):
+            # communicate() raises ValueError if the stop endpoint already called
+            # terminate() + wait() and closed the pipe; treat as terminated.
+            _set_job(job_id, {"status": "error", "action": f"race_{action}", "error": "terminated"})
         except Exception as exc:
             _set_job(job_id, {"status": "error", "action": f"race_{action}", "error": str(exc)})
         finally:
@@ -2559,7 +2572,11 @@ async def serve_photo(filename: str):
     if not re.fullmatch(r"[\w\-]+\.jpe?g", filename, re.IGNORECASE):
         from fastapi import HTTPException
         raise HTTPException(status_code=404, detail="not found")
+    photos_root = (PROJECT_ROOT / "photos").resolve()
     photo_path = PROJECT_ROOT / "photos" / filename
+    if photo_path.resolve().parent != photos_root:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail="not found")
     if not photo_path.exists():
         from fastapi import HTTPException
         raise HTTPException(status_code=404, detail="photo not found")

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -124,6 +124,16 @@ def _check_public_rate_limit(ip: str) -> bool:
                      if not v or now - v[-1] > _PUBLIC_RATE_WINDOW_S]
             for k in stale[:len(_public_rate_store) - 10000]:
                 del _public_rate_store[k]
+            # Under a flood of fresh IPs stale eviction may yield nothing; fall
+            # back to evicting the oldest-accessed IPs to keep the store capped.
+            if len(_public_rate_store) > 10000:
+                overflow = len(_public_rate_store) - 10000
+                oldest = sorted(
+                    _public_rate_store.keys(),
+                    key=lambda k: _public_rate_store[k][-1] if _public_rate_store[k] else 0,
+                )[:overflow]
+                for k in oldest:
+                    del _public_rate_store[k]
         return True
 
 
@@ -341,7 +351,8 @@ def _set_job(job_id: str, data: Dict[str, Any]) -> None:
 
 def _get_job(job_id: str) -> Optional[Dict[str, Any]]:
     with _jobs_lock:
-        return _jobs.get(job_id)
+        data = _jobs.get(job_id)
+        return data.copy() if data is not None else None
 
 
 # ---------------------------------------------------------------------------
@@ -1455,6 +1466,7 @@ async def get_job(job_id: str) -> Dict[str, Any]:
 
 # Track active race process so we can stop it
 _race_proc: Optional[subprocess.Popen] = None
+_race_starting: bool = False  # sentinel: True between check and Popen assignment
 _race_proc_lock = threading.Lock()
 
 
@@ -1467,7 +1479,7 @@ class RaceRequest(BaseModel):
 @app.post("/api/v1/race/{action}", dependencies=[Depends(_verify_token)])
 async def race_action(action: str, request: Request) -> JSONResponse:
     """Start/stop race commands. Actions: map, race, stop, status, calibrate_gate."""
-    global _race_proc
+    global _race_proc, _race_starting
 
     if action == "stop":
         with _race_proc_lock:
@@ -1496,22 +1508,26 @@ async def race_action(action: str, request: Request) -> JSONResponse:
     if action not in ("map", "race", "calibrate_gate"):
         raise HTTPException(status_code=400, detail=f"unknown action: {action}")
 
-    # Don't start if already running
+    # Don't start if already running. Set _race_starting sentinel atomically so a
+    # second concurrent request can't slip through before the worker assigns _race_proc.
     with _race_proc_lock:
-        if _race_proc and _race_proc.poll() is None:
+        if (_race_proc and _race_proc.poll() is None) or _race_starting:
             return JSONResponse(
                 status_code=409,
                 content={"status": "already_running", "detail": "stop current race first"},
             )
+        _race_starting = True
 
-    # Parse request body (all actions may carry a dry field). Validate via
-    # RaceRequest so bad JSON shapes return 422 instead of crashing the route
-    # with a 500 from int() on a non-numeric value (issue #151).
+    # Parse request body. Validate via RaceRequest so bad JSON shapes return
+    # 422 instead of crashing with a 500 (issue #151). Distinguish empty body
+    # (use defaults) from malformed JSON (return 400).
+    body_bytes = await request.body()
     raw_body: dict = {}
-    try:
-        raw_body = await request.json()
-    except Exception:
-        pass
+    if body_bytes:
+        try:
+            raw_body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="malformed JSON body") from None
     try:
         parsed = RaceRequest(**raw_body) if raw_body else RaceRequest()
     except ValidationError as exc:
@@ -1545,7 +1561,7 @@ async def race_action(action: str, request: Request) -> JSONResponse:
         # Hold a local reference to the popen — never re-read the global after
         # spawn (issue #146). Stop endpoint nulls the global; reading
         # _race_proc.returncode after that would raise AttributeError.
-        global _race_proc
+        global _race_proc, _race_starting
         proc: subprocess.Popen | None = None
         try:
             env = os.environ.copy()
@@ -1556,6 +1572,7 @@ async def race_action(action: str, request: Request) -> JSONResponse:
                     env=env, cwd=str(PROJECT_ROOT),
                 )
                 _race_proc = proc
+                _race_starting = False  # sentinel cleared once proc is assigned
             stdout, stderr = proc.communicate(timeout=600)
             _set_job(job_id, {
                 "status": "complete" if proc.returncode == 0 else "error",
@@ -1576,6 +1593,7 @@ async def race_action(action: str, request: Request) -> JSONResponse:
                 # racing with a subsequent race start that wrote a new value.
                 if _race_proc is proc:
                     _race_proc = None
+                _race_starting = False  # always clear on any exit path
 
     _executor.submit(_run_race)
     return JSONResponse(

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -1173,16 +1173,17 @@ async def public_chat(req: PublicChatRequest, request: Request):
         )
 
     def _sanitize_chat_text(text: str) -> str:
-        """Strip newlines and role-tag brackets to prevent prompt injection."""
-        return text.replace("\n", " ").replace("\r", " ").replace("[", "(").replace("]", ")")
+        """Collapse whitespace and strip NUL bytes from user-supplied text."""
+        return text.replace("\n", " ").replace("\r", " ").replace("\x00", "")
 
-    # Build structured prompt to prevent injection via history content
+    # Use XML-style role tags with a namespace prefix that user content cannot
+    # replicate — bracket-only tags like [USER]: are trivially injected.
     history_block = "\n".join(
-        f"[{'USER' if item.role == 'user' else 'SPARK'}]: {_sanitize_chat_text(item.text)}"
+        f"<spark:{'user' if item.role == 'user' else 'assistant'}>{_sanitize_chat_text(item.text)}</spark:{'user' if item.role == 'user' else 'assistant'}>"
         for item in req.history
     )
     prompt = (history_block + "\n" if history_block else "") + \
-             f"[USER]: {_sanitize_chat_text(req.message)}\n[SPARK]:"
+             f"<spark:user>{_sanitize_chat_text(req.message)}</spark:user>\n<spark:assistant>"
     ctx = _build_public_context()
     if ctx:
         prompt = ctx + "\n\n" + prompt
@@ -1402,8 +1403,8 @@ async def run_tool(body: ToolRequest) -> JSONResponse:
                         "last_action": tool,
                         "last_action_ts": utc_timestamp(),
                     })
-                except Exception:
-                    pass  # non-critical
+                except Exception as _exc:
+                    logging.getLogger("pxh.api").warning("update_session post-tool failed: %s", _exc)
 
         asyncio.create_task(_run_async())
         return JSONResponse(

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -1211,7 +1211,11 @@ async def public_chat(req: PublicChatRequest, request: Request):
             content={"error": "Something went quiet on my end. Try again?"},
         )
 
-    if not reply.strip():
+    # Claude sometimes echoes the opening/closing XML role tags into stdout when
+    # the prompt ends with <spark:assistant>. Strip them so they don't leak to clients.
+    reply = reply.removeprefix("<spark:assistant>").removesuffix("</spark:assistant>").strip()
+
+    if not reply:
         _public_chat_log.warning("public_chat: empty stdout from claude (exit 0), ip=%s", ip_hash)
         reply = "I'm here — I just went quiet for a moment. Try again?"
 

--- a/src/pxh/mind.py
+++ b/src/pxh/mind.py
@@ -898,6 +898,8 @@ def _detect_findmyhub_arrivals(findmyhub: dict) -> list[str]:
     if not findmyhub:
         return transitions
     for tracker_name, curr_data in findmyhub.items():
+        if not isinstance(curr_data, dict):
+            continue
         prev_data = _last_known_findmyhub.get(tracker_name)
         if (
             curr_data.get("at_home")
@@ -1447,15 +1449,10 @@ def battery_emergency_shutdown(pct: int, dry: bool) -> None:
 
     _play_alarm_beeps(6, device)
 
-    env["PX_TEXT"] = f"Battery critical! Only {pct} percent remaining! I need to shut down right now!"
+    # Short timeout (5s) — battery is critical, don't let TTS delay shutdown
+    env["PX_TEXT"] = f"Battery critical! Only {pct} percent remaining! Shutting down now!"
     subprocess.run([str(BIN_DIR / "tool-voice")], env=env,
-                   capture_output=True, check=False, timeout=20)
-
-    _play_alarm_beeps(4, device)
-
-    env["PX_TEXT"] = "Please charge me soon. Goodbye!"
-    subprocess.run([str(BIN_DIR / "tool-voice")], env=env,
-                   capture_output=True, check=False, timeout=15)
+                   capture_output=True, check=False, timeout=5)
 
     _play_alarm_beeps(3, device)
 

--- a/src/pxh/race.py
+++ b/src/pxh/race.py
@@ -93,17 +93,20 @@ class GateDetector:
 
         if self._pending_count > 0:
             self._pending_frames += 1
-            self._pending_count += triggered_this_frame
-
-            if self._pending_count >= 2:
-                self._last_trigger_t = t
-                self._pending_count = 0
-                self._pending_frames = 0
-                return True
-
+            # Check expiry BEFORE accumulating count: if the confirm window has
+            # elapsed, abandon the pending state so a trigger on the expiry frame
+            # doesn't fire via the count check below (issue: count was incremented
+            # first, then expiry was checked, allowing a false gate detection).
             if self._pending_frames > self.confirm_frames:
                 self._pending_frames = 0
                 self._pending_count = 0
+            else:
+                self._pending_count += triggered_this_frame
+                if self._pending_count >= 2:
+                    self._last_trigger_t = t
+                    self._pending_count = 0
+                    self._pending_frames = 0
+                    return True
 
         if triggered_this_frame >= 2:
             self._last_trigger_t = t

--- a/src/pxh/state.py
+++ b/src/pxh/state.py
@@ -24,8 +24,9 @@ LOCK_TIMEOUT_S = 10  # seconds — fail fast rather than hang forever
 def atomic_write(path: Path, content: str) -> None:
     """Write content to path atomically via temp file + os.replace.
 
-    Preserves original file's ownership and sets mode 0o644 so that
-    cross-user writers (root px-alive, pi px-mind) don't lock each other out.
+    Attempts to preserve original file's ownership (skipped silently if caller
+    lacks privileges) and sets mode 0o644 so that cross-user writers
+    (root px-alive, pi px-mind) don't lock each other out.
     """
     # Capture original ownership before replacing
     try:

--- a/src/pxh/voice_loop.py
+++ b/src/pxh/voice_loop.py
@@ -758,6 +758,7 @@ def execute_tool(tool: str, env_overrides: Dict[str, str], dry_mode: bool, timeo
         elapsed = time.monotonic() - _last_tool_execution
         if elapsed < 0.5:
             time.sleep(0.5 - elapsed)
+        _last_tool_execution = time.monotonic()
 
     command_path = TOOL_COMMANDS[tool]
     if not command_path.exists():
@@ -789,8 +790,6 @@ def execute_tool(tool: str, env_overrides: Dict[str, str], dry_mode: bool, timeo
         )
     except subprocess.TimeoutExpired:
         return 1, json.dumps({"status": "error", "error": f"tool {tool} timed out after {timeout}s"}), ""
-    finally:
-        _last_tool_execution = time.monotonic()
     return result.returncode, result.stdout, result.stderr
 
 

--- a/src/pxh/voice_loop.py
+++ b/src/pxh/voice_loop.py
@@ -797,6 +797,13 @@ def supervisor_loop(args: argparse.Namespace) -> None:
     ensure_session()
     system_prompt = read_prompt(Path(args.prompt))
 
+    # Install SIGTERM handler so the watchdog's os.kill(SIGTERM) triggers
+    # SystemExit rather than the default C-level termination, allowing Python
+    # atexit handlers and finally blocks (including FileLock release) to run.
+    def _sigterm(signum, frame):
+        raise SystemExit(0)
+    signal.signal(signal.SIGTERM, _sigterm)
+
     heartbeat_lock = threading.Lock()
     heartbeat_val: list = [time.monotonic()]
     if args.input_mode != "text":

--- a/tests/test_evolve_coverage.py
+++ b/tests/test_evolve_coverage.py
@@ -198,7 +198,7 @@ class TestReflectionIntrospectionTs:
             awareness = {"time_of_day": "afternoon", "obi_mode": "calm"}
             result = mind.reflection(awareness, dry=True)
             # Should not crash — that's the main assertion
-            assert result is not None or result is None  # no crash
+            assert result is None or isinstance(result, dict)  # returns dict|None per type hint
 
     def test_iso_string_ts(self, tmp_path):
         """reflection() should handle ISO string ts (backward compat)."""

--- a/tests/test_mind_utils.py
+++ b/tests/test_mind_utils.py
@@ -231,13 +231,12 @@ def test_frigate_presence_below_min_score():
 
 
 def test_frigate_presence_low_score():
-    """A low-score event (< 0.5) → not a confident detection."""
+    """A low-score event (0.3 < FRIGATE_MIN_SCORE=0.6) → person_present is False."""
     events = [_make_frigate_event(score=0.3)]
     with patch("urllib.request.urlopen", side_effect=_mock_urlopen_fn(events)):
         result = _fetch_frigate_presence(dry=False)
     assert result is not None
-    # Low-score may or may not be counted as person detected depending on threshold
-    # but the function should not crash
+    assert result.get("person_present") is False
 
 
 def test_frigate_presence_multi_camera():


### PR DESCRIPTION
## Summary

- Eleven batches of QA audit fixes across the full codebase, reviewed independently by four agent CLIs (Hermes, Agy, Gemini, Codex)
- Fixes cover: og-rewrite HTMLRewriter, px-motd path resolution, battery shutdown guard, watchdog SIGTERM handler, blog log lock, async exception logging, chat injection hardening, race sentinel deadlock, job eviction, pipe race, path traversal, session token thread safety, dashboard JS, GateDetector expiry bug, DOM clobbering, motd state clamp, atomic_write docstring, persona tool_story, and more
- Adds HANDOFF.md with session notes, system status, and next-session candidates

## Test plan

- [ ] `python -m pytest` passes (716 tests, no regressions)
- [ ] `python -m pytest -m "not live"` passes (691 tests)
- [ ] Deploy to Pi and confirm `px-motd` renders correctly
- [ ] Confirm `px-mind` and `px-api-server` services healthy after deploy