### PR TITLE
chore(systemd): add daily pip /tmp scratch cleanup timer

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,22 @@
+# systemd units
+
+Service units for the eleven SPARK daemons (see CLAUDE.md "Systemd Services").
+Install to `/etc/systemd/system/` on the Pi, then `daemon-reload` + `enable --now`.
+
+## Maintenance timer: pip /tmp cleanup
+
+`spark-pip-cleanup.timer` sweeps leftover `/tmp/pip-*` scratch dirs (older than
+1 day) left behind by failed/interrupted pip installs. Debian's default `/tmp`
+policy only wipes on reboot, so they accumulate across uptime — an interrupted
+install once left 4.5G behind. Install:
+
+```bash
+sudo cp systemd/spark-pip-cleanup.sh /usr/local/sbin/spark-pip-cleanup.sh
+sudo chown root:root /usr/local/sbin/spark-pip-cleanup.sh
+sudo chmod 755 /usr/local/sbin/spark-pip-cleanup.sh
+sudo cp systemd/spark-pip-cleanup.service systemd/spark-pip-cleanup.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now spark-pip-cleanup.timer
+```
+
+Verify: `systemctl list-timers spark-pip-cleanup.timer`.

--- a/systemd/spark-pip-cleanup.service
+++ b/systemd/spark-pip-cleanup.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Sweep leftover pip scratch dirs in /tmp (failed install cleanup)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/spark-pip-cleanup.sh

--- a/systemd/spark-pip-cleanup.sh
+++ b/systemd/spark-pip-cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Sweep leftover pip build/unpack scratch dirs from failed/interrupted installs.
+# pip normally cleans these, but an interrupted run (e.g. OOM) leaves them behind.
+# Default Debian /tmp policy only wipes on reboot, so they accumulate across uptime.
+# Install to /usr/local/sbin/spark-pip-cleanup.sh (root:root, 0755).
+find /tmp -maxdepth 1 -name 'pip-*' -mtime +1 -exec rm -rf {} + 2>/dev/null
+exit 0

--- a/systemd/spark-pip-cleanup.timer
+++ b/systemd/spark-pip-cleanup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily sweep of leftover pip scratch dirs in /tmp
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

Adds a daily systemd timer that sweeps leftover `/tmp/pip-*` scratch dirs (older than 1 day) left behind by failed or interrupted pip installs.

## Why

An interrupted pip install on the Pi once left **4.5G** of `pip-unpack-*` / `pip-build-tracker-*` dirs in `/tmp`, filling the SD card to 97% (935M free). Debian's default `/tmp` policy only wipes on reboot, so they accumulate across uptime.

## Files

- `systemd/spark-pip-cleanup.sh` — `find /tmp -maxdepth 1 -name 'pip-*' -mtime +1 -exec rm -rf`. Targets only `pip-*`, so live sockets (`.X11-unix`, `tmux-*`, `ssh-*`) are never touched; 1-day age means in-progress installs are safe.
- `systemd/spark-pip-cleanup.service` — oneshot
- `systemd/spark-pip-cleanup.timer` — `OnCalendar=daily`, `Persistent=true`
- `systemd/README.md` — install instructions (dir had no README before)

## Status

Units are **already installed and running on the live Pi** (test run passed, `Result=success`). This PR just version-controls them so they survive an SD reflash. No code paths changed; nothing to run in CI beyond the existing suite.