### PR TITLE
fix(px-post): stop runaway CPU from cursor replay + O(N²) queue

### DIFF
--- a/bin/px-post
+++ b/bin/px-post
@@ -402,11 +402,11 @@ def _load_cursor() -> dict:
         return json.loads(CURSOR_FILE.read_text())
     except (FileNotFoundError, json.JSONDecodeError) as exc:
         log(f"cursor reset (fresh start): {exc}")
-        return {"offset": 0, "inode": 0}
+        return {}
 
 
-def _save_cursor(offset: int, inode: int) -> None:
-    data = {"file": "thoughts-spark.jsonl", "offset": offset, "inode": inode,
+def _save_cursor(last_ts: str) -> None:
+    data = {"file": "thoughts-spark.jsonl", "last_ts": last_ts, "initialized": True,
             "last_poll_ts": dt.datetime.now(dt.timezone.utc).isoformat()}
     try:
         # Atomic write
@@ -421,39 +421,34 @@ def _save_cursor(offset: int, inode: int) -> None:
 
 
 def poll_new_thoughts(thoughts_file: Path) -> list[dict]:
-    """Read new complete lines from thoughts file since last cursor position."""
+    """Return thought entries newer (by ``ts``) than the cursor.
+
+    The cursor tracks the timestamp of the last processed thought rather than a
+    byte offset, so it is immune to the atomic rewrites and rolling-window
+    truncation that px-mind performs on thoughts-spark.jsonl. A byte-offset
+    cursor reset to 0 on every inode change / shrink and re-processed the entire
+    10k-line window each time — the runaway-CPU bug this replaces.
+
+    On a fresh start (no initialized cursor) it records the latest ts and returns
+    nothing: the daemon does not replay history. Use ``--backfill`` to seed the
+    feed from past thoughts intentionally.
+    """
     cursor = _load_cursor()
     try:
-        st = thoughts_file.stat()
+        raw = thoughts_file.read_text(encoding="utf-8", errors="replace")
     except FileNotFoundError:
         return []
 
-    if st.st_ino != cursor.get("inode", 0):
-        # Inode changed (e.g. atomic_write os.replace). If the file is at least
-        # as large as our stored offset the content is intact — keep the offset.
-        # Only reset if the new file is shorter (genuine replacement).
-        if st.st_size < cursor.get("offset", 0):
-            log("cursor: inode changed, file shrunk — resetting to 0")
-            cursor["offset"] = 0
-        else:
-            log("cursor: inode changed, file intact — keeping offset")
-    elif st.st_size < cursor.get("offset", 0):
-        log("cursor: file shrunk — resetting to 0")
-        cursor["offset"] = 0
-
-    with thoughts_file.open("rb") as f:
-        f.seek(cursor["offset"])
-        raw = f.read()
-
-    # Only process complete lines (ending in \n)
-    last_nl = raw.rfind(b"\n")
+    # Only consider complete lines (the final line must end with a newline).
+    last_nl = raw.rfind("\n")
     if last_nl == -1:
-        return []  # no complete lines
-    processable = raw[:last_nl + 1]
-    new_offset = cursor["offset"] + len(processable)
+        return []
+    raw = raw[:last_nl + 1]
 
-    entries = []
-    for line in processable.decode("utf-8", errors="replace").splitlines():
+    last_ts = cursor.get("last_ts", "")
+    max_ts = last_ts
+    parsed: list[tuple[str, dict]] = []
+    for line in raw.splitlines():
         line = line.strip()
         if not line:
             continue
@@ -465,10 +460,20 @@ def poll_new_thoughts(thoughts_file: Path) -> list[dict]:
         if not REQUIRED_FIELDS.issubset(entry.keys()):
             log(f"malformed entry skipped: {list(entry.keys())}")
             continue
-        entries.append(entry)
+        ts = entry.get("ts", "")
+        parsed.append((ts, entry))
+        if ts > max_ts:
+            max_ts = ts
 
-    _save_cursor(new_offset, st.st_ino)
-    return entries
+    # Fresh / legacy / corrupt cursor: record position, do not replay the backlog.
+    if not cursor.get("initialized"):
+        _save_cursor(max_ts)
+        return []
+
+    new_entries = [entry for ts, entry in parsed if ts > last_ts]
+    if max_ts > last_ts:
+        _save_cursor(max_ts)
+    return new_entries
 
 
 FEED_FILE = STATE_DIR / "feed.json"
@@ -717,15 +722,9 @@ def _generate_post_id() -> str:
     return f"post-{dt.datetime.now().strftime('%Y%m%d-%H%M%S')}-{_SYS_RNG.randint(0, 999):03d}"
 
 
-def queue_thought(entry: dict) -> None:
-    """Append a qualifying thought to the post queue. Skips if already queued (dedup)."""
-    # Check for duplicates in existing queue
-    existing = _load_queue()
-    new_thought = entry["thought"][:100]
-    for existing_entry in existing:
-        if existing_entry.get("thought", "")[:100] == new_thought:
-            return  # already queued
-    queue_entry = {
+def _build_queue_entry(entry: dict) -> dict:
+    """Build a queue record from a thought entry."""
+    return {
         "id": _generate_post_id(),
         "ts": entry.get("ts", ""),
         "thought": entry["thought"],
@@ -736,12 +735,65 @@ def queue_thought(entry: dict) -> None:
         "qa_result": None,
         "posted": {"feed": None, "bluesky": None},
     }
+
+
+def _entry_posted_to_feed(entry: dict) -> bool:
+    """True if a queue entry has been successfully written to the feed."""
+    fv = (entry.get("posted") or {}).get("feed")
+    return fv is not None and not (isinstance(fv, str) and fv.startswith("error:"))
+
+
+def _trim_queue(entries: list[dict]) -> list[dict]:
+    """Cap the queue at QUEUE_LIMIT, preferring to keep entries not yet posted.
+
+    Dropping the oldest entries blindly could discard un-posted thoughts in favour
+    of already-posted ones, so un-posted entries are retained first; remaining
+    capacity is filled with the most-recent posted entries. Original order kept.
+    """
+    if len(entries) <= QUEUE_LIMIT:
+        return entries
+    keep = set()
+    unposted = [e for e in entries if not _entry_posted_to_feed(e)]
+    if len(unposted) >= QUEUE_LIMIT:
+        for e in unposted[-QUEUE_LIMIT:]:
+            keep.add(id(e))
+    else:
+        for e in unposted:
+            keep.add(id(e))
+        room = QUEUE_LIMIT - len(unposted)
+        posted = [e for e in entries if _entry_posted_to_feed(e)]
+        for e in posted[-room:] if room else []:
+            keep.add(id(e))
+    return [e for e in entries if id(e) in keep]
+
+
+def _append_queue(new_entries: list[dict]) -> None:
+    """Add already-built queue records, deduped against the queue, capped at QUEUE_LIMIT.
+
+    Loads the queue once and rewrites atomically — avoids the per-entry reload
+    and the unbounded open("a") append that let the queue grow to thousands of
+    entries.
+    """
+    if not new_entries:
+        return
     STATE_DIR.mkdir(parents=True, exist_ok=True)
-    try:
-        with QUEUE_FILE.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(queue_entry) + "\n")
-    except OSError as exc:
-        log(f"queue_thought failed: {exc}")
+    existing = _load_queue()
+    seen = {e.get("thought", "")[:100] for e in existing}
+    to_add = []
+    for e in new_entries:
+        key = e.get("thought", "")[:100]
+        if key in seen:
+            continue
+        seen.add(key)
+        to_add.append(e)
+    if not to_add:
+        return
+    _save_queue(_trim_queue(existing + to_add))
+
+
+def queue_thought(entry: dict) -> None:
+    """Append a qualifying thought to the post queue. Skips if already queued (dedup)."""
+    _append_queue([_build_queue_entry(entry)])
 
 
 def _load_queue() -> list[dict]:
@@ -784,7 +836,7 @@ def _save_queue(entries: list[dict]) -> None:
                     pass
         except OSError:
             pass
-    entries = entries[-QUEUE_LIMIT:]
+    entries = _trim_queue(entries)
     fd, tmp = tempfile.mkstemp(dir=str(STATE_DIR), suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -1091,11 +1143,28 @@ def main(argv: list[str]) -> int:
                 pass
 
             try:
-                queued_count = 0
-                for entry in new_thoughts:
-                    if qualifies(entry) and not is_duplicate(entry["thought"], feed_posts):
-                        queue_thought(entry)
-                        queued_count += 1
+                # Load the queue once per cycle (not once per entry) and collect
+                # qualifying thoughts for a single batched, capped append. The old
+                # per-entry queue_thought() re-parsed the whole queue file every
+                # iteration — O(N^2) that pegged a core on large batches.
+                existing_queue = _load_queue()
+                queued_keys = {e.get("thought", "")[:100] for e in existing_queue}
+                to_queue = []
+                for i, entry in enumerate(new_thoughts):
+                    if _shutdown.is_set():
+                        break  # stay responsive to SIGTERM mid-batch
+                    if i and i % 100 == 0:
+                        last_cycle = time.monotonic()  # keep the watchdog fed
+                    if not (qualifies(entry) and not is_duplicate(entry["thought"], feed_posts)):
+                        continue
+                    key = entry["thought"][:100]
+                    if key in queued_keys:
+                        continue
+                    queued_keys.add(key)
+                    to_queue.append(_build_queue_entry(entry))
+                if to_queue:
+                    _append_queue(to_queue)
+                queued_count = len(to_queue)
                 if new_thoughts or queued_count:
                     log(f"poll: {len(new_thoughts)} new thoughts, {queued_count} queued")
             except Exception as exc:

--- a/bin/px-post
+++ b/bin/px-post
@@ -862,8 +862,14 @@ def _is_in_feed(thought_text: str, feed_posts: list[dict]) -> bool:
     return False
 
 
-def flush_queue(bluesky: 'BlueskyClient', dry: bool) -> dict:
-    """Two-pass flush: batch all feed writes, then one social post. Never blocks feed on social rate limits."""
+def flush_queue(bluesky: 'BlueskyClient', dry: bool, should_stop=None) -> dict:
+    """Two-pass flush: batch all feed writes, then one social post. Never blocks feed on social rate limits.
+
+    ``should_stop`` is an optional predicate; when it returns True the flush bails
+    out between entries so SIGTERM stays responsive even with a full queue (each
+    entry can spend seconds in the QA gate).
+    """
+    _stop = should_stop or (lambda: False)
     entries = _load_queue()
     if not entries:
         return {"processed": 0, "posted": False, "rejected": False}
@@ -882,6 +888,9 @@ def flush_queue(bluesky: 'BlueskyClient', dry: bool) -> dict:
 
     # ── Pass 1: Batch all feed writes (local, no rate limit) ──
     for entry in entries:
+        if _stop():
+            log("flush: shutdown requested — stopping early (pass 1)")
+            break
         posted = entry.get("posted", {})
         if posted.get("feed") is not None and not (isinstance(posted.get("feed"), str) and posted["feed"].startswith("error:")):
             continue  # feed already done
@@ -933,6 +942,9 @@ def flush_queue(bluesky: 'BlueskyClient', dry: bool) -> dict:
         feed_texts = set()
 
     for entry in entries:
+        if _stop():
+            log("flush: shutdown requested — stopping early (pass 2)")
+            break
         entry.setdefault("posted", {"feed": None, "bluesky": None})
         posted = entry["posted"]
         # Need Bluesky posting?
@@ -1178,7 +1190,7 @@ def main(argv: list[str]) -> int:
             if now - last_flush >= args.flush_interval:
                 log(f"flush: starting (interval={args.flush_interval}s, bsky_ok={bluesky.available()}, queue={len(_load_queue())})")
                 try:
-                    result = flush_queue(bluesky, dry)
+                    result = flush_queue(bluesky, dry, should_stop=_shutdown.is_set)
                 except Exception as exc:
                     log(f"flush: CRASHED: {exc}")
                     result = {"posted": False, "rejected": False, "processed": 0}

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -72,9 +72,12 @@ run_backfill = _POST["run_backfill"]
 STATUS_FILE = _POST["STATUS_FILE"]
 
 
-def _make_line(thought="hello", salience=0.8, action="comment"):
+def _make_line(thought="hello", salience=0.8, action="comment", ts="2026-01-01T00:00:00Z"):
     """Build a valid JSONL line (with trailing newline)."""
-    return json.dumps({"thought": thought, "salience": salience, "action": action}) + "\n"
+    entry = {"thought": thought, "salience": salience, "action": action}
+    if ts is not None:
+        entry["ts"] = ts
+    return json.dumps(entry) + "\n"
 
 
 def _patch_state_dir(mod_globals, tmp_path):
@@ -166,102 +169,122 @@ def _cursor_env(tmp_path):
     _POST["FEED_FILE"] = orig_feed
 
 
-def test_file_offset_cursor(_cursor_env):
-    """Poll reads new entries and advances cursor; second poll returns only new."""
+def _ts(n):
+    """Monotonic ISO-ish timestamp for ordering thoughts in cursor tests."""
+    return f"2026-01-01T00:00:{n:02d}Z"
+
+
+def test_first_poll_initializes_without_replay(_cursor_env):
+    """Fresh cursor: first poll records position and returns nothing (no backlog replay)."""
     tmp = _cursor_env
     tf = tmp / "thoughts-spark.jsonl"
-    tf.write_text(_make_line("a") + _make_line("b") + _make_line("c"))
+    tf.write_text(_make_line("a", ts=_ts(1)) + _make_line("b", ts=_ts(2)) + _make_line("c", ts=_ts(3)))
 
     results = poll_new_thoughts(tf)
-    assert len(results) == 3
-    assert [r["thought"] for r in results] == ["a", "b", "c"]
+    assert results == []  # daemon does not replay history on first start
 
-    # Append 2 more lines
+    # Subsequent appends (newer ts) are returned
     with tf.open("a") as f:
-        f.write(_make_line("d") + _make_line("e"))
-
+        f.write(_make_line("d", ts=_ts(4)) + _make_line("e", ts=_ts(5)))
     results2 = poll_new_thoughts(tf)
-    assert len(results2) == 2
     assert [r["thought"] for r in results2] == ["d", "e"]
 
 
-def test_file_shrink_resets_cursor(_cursor_env):
-    """Truncated file resets cursor to 0 and re-reads from start."""
+def test_poll_returns_only_newer_by_ts(_cursor_env):
+    """After init, only entries with ts strictly greater than the cursor are returned."""
     tmp = _cursor_env
     tf = tmp / "thoughts-spark.jsonl"
-    tf.write_text(_make_line("a") + _make_line("b") + _make_line("c"))
+    tf.write_text(_make_line("a", ts=_ts(1)))
+    poll_new_thoughts(tf)  # initialize at ts 1
 
-    poll_new_thoughts(tf)  # advance cursor
-
-    # Truncate to shorter content
-    tf.write_text(_make_line("x"))
-    results = poll_new_thoughts(tf)
-    assert len(results) == 1
-    assert results[0]["thought"] == "x"
+    with tf.open("a") as f:
+        f.write(_make_line("b", ts=_ts(2)) + _make_line("c", ts=_ts(3)))
+    assert [r["thought"] for r in poll_new_thoughts(tf)] == ["b", "c"]
+    # Re-poll with no new content returns nothing
+    assert poll_new_thoughts(tf) == []
 
 
-def test_cursor_inode_change(_cursor_env):
-    """Deleting and recreating the file (new inode) resets cursor."""
+def test_cursor_survives_atomic_rewrite_no_replay(_cursor_env):
+    """REGRESSION: a rolling-window atomic rewrite (new inode, shrunk) must NOT replay the file.
+
+    This is the runaway-CPU bug: the old byte-offset cursor reset to 0 on inode
+    change / shrink and re-processed all 10k lines on every px-mind rewrite.
+    """
     tmp = _cursor_env
     tf = tmp / "thoughts-spark.jsonl"
-    tf.write_text(_make_line("a") + _make_line("b"))
+    # Start with a long window a..e and initialize the cursor at the newest (e/ts5).
+    tf.write_text("".join(_make_line(c, ts=_ts(i + 1)) for i, c in enumerate("abcde")))
+    poll_new_thoughts(tf)  # init at ts 5
 
-    poll_new_thoughts(tf)  # advance cursor
-
-    # Delete and recreate (different inode)
+    # px-mind rewrites atomically: new inode, SHORTER file (rolling window dropped
+    # a,b) and appends one genuinely new thought f/ts6.
     tf.unlink()
-    tf.write_text(_make_line("new"))
+    tf.write_text("".join(_make_line(c, ts=_ts(i)) for c, i in [("c", 3), ("d", 4), ("e", 5), ("f", 6)]))
 
     results = poll_new_thoughts(tf)
-    assert len(results) == 1
-    assert results[0]["thought"] == "new"
+    assert [r["thought"] for r in results] == ["f"]  # only the new one, NOT the whole file
 
 
-def test_cursor_corrupt_resets(_cursor_env):
-    """Corrupt cursor file causes reset to offset 0 without crashing."""
+def test_corrupt_cursor_reinitializes_without_replay(_cursor_env):
+    """Corrupt cursor file reinitializes cleanly (no crash, no backlog replay)."""
     tmp = _cursor_env
     tf = tmp / "thoughts-spark.jsonl"
-    tf.write_text(_make_line("a"))
-
-    # Write garbage to cursor file
-    cursor_f = tmp / "px-post-cursor.json"
-    cursor_f.write_text("{{{not json at all!!!")
+    tf.write_text(_make_line("a", ts=_ts(1)) + _make_line("b", ts=_ts(2)))
+    (tmp / "px-post-cursor.json").write_text("{{{not json at all!!!")
 
     results = poll_new_thoughts(tf)
-    assert len(results) == 1
-    assert results[0]["thought"] == "a"
+    assert results == []  # treated as fresh start, no replay
+    with tf.open("a") as f:
+        f.write(_make_line("c", ts=_ts(3)))
+    assert [r["thought"] for r in poll_new_thoughts(tf)] == ["c"]
+
+
+def test_legacy_offset_cursor_migrates_without_replay(_cursor_env):
+    """An old-format (offset/inode) cursor migrates to ts-based without replaying."""
+    tmp = _cursor_env
+    tf = tmp / "thoughts-spark.jsonl"
+    tf.write_text(_make_line("a", ts=_ts(1)) + _make_line("b", ts=_ts(2)))
+    # Simulate the pre-fix cursor on disk.
+    (tmp / "px-post-cursor.json").write_text(json.dumps({"file": "thoughts-spark.jsonl", "offset": 999, "inode": 123}))
+
+    results = poll_new_thoughts(tf)
+    assert results == []  # no legacy last_ts → fresh init, no replay
+    with tf.open("a") as f:
+        f.write(_make_line("c", ts=_ts(3)))
+    assert [r["thought"] for r in poll_new_thoughts(tf)] == ["c"]
 
 
 def test_partial_line_not_consumed(_cursor_env):
-    """Incomplete line (no trailing newline) is not returned."""
+    """Incomplete line (no trailing newline) is not returned until completed."""
     tmp = _cursor_env
     tf = tmp / "thoughts-spark.jsonl"
-    complete = _make_line("complete")
-    partial = json.dumps({"thought": "partial", "salience": 0.8, "action": "comment"})
-    # partial has no trailing \n
-    tf.write_text(complete + partial)
+    tf.write_text(_make_line("seed", ts=_ts(1)))
+    poll_new_thoughts(tf)  # init at ts 1
+
+    complete = _make_line("complete", ts=_ts(2))
+    partial = json.dumps({"thought": "partial", "salience": 0.8, "action": "comment", "ts": _ts(3)})
+    with tf.open("a") as f:
+        f.write(complete + partial)  # partial has no trailing newline
 
     results = poll_new_thoughts(tf)
-    assert len(results) == 1
-    assert results[0]["thought"] == "complete"
+    assert [r["thought"] for r in results] == ["complete"]
 
-    # Now finish the partial line
     with tf.open("a") as f:
-        f.write("\n")
-
+        f.write("\n")  # finish the partial line
     results2 = poll_new_thoughts(tf)
-    assert len(results2) == 1
-    assert results2[0]["thought"] == "partial"
+    assert [r["thought"] for r in results2] == ["partial"]
 
 
 def test_corrupt_jsonl_skipped(_cursor_env):
-    """Corrupt JSONL line is skipped; valid lines on both sides are returned."""
+    """Corrupt JSONL line is skipped; valid newer lines on both sides are returned."""
     tmp = _cursor_env
     tf = tmp / "thoughts-spark.jsonl"
-    tf.write_text(_make_line("good1") + "NOT VALID JSON\n" + _make_line("good2"))
+    tf.write_text(_make_line("seed", ts=_ts(1)))
+    poll_new_thoughts(tf)  # init at ts 1
 
+    with tf.open("a") as f:
+        f.write(_make_line("good1", ts=_ts(2)) + "NOT VALID JSON\n" + _make_line("good2", ts=_ts(3)))
     results = poll_new_thoughts(tf)
-    assert len(results) == 2
     assert [r["thought"] for r in results] == ["good1", "good2"]
 
 
@@ -555,6 +578,55 @@ def _make_queue_entry(thought="test thought", posted=None, qa_result="pass", ent
         "qa_result": qa_result,
         "posted": posted or {"feed": None, "bluesky": None},
     }
+
+
+def test_trim_queue_caps_at_limit(_cursor_env):
+    """_trim_queue caps the queue at QUEUE_LIMIT entries."""
+    _trim_queue = _POST["_trim_queue"]
+    limit = _POST["QUEUE_LIMIT"]
+    entries = [_make_queue_entry(f"t{i}", posted={"feed": "ok", "bluesky": "ok"}, entry_id=f"id-{i}")
+               for i in range(limit + 50)]
+    trimmed = _trim_queue(entries)
+    assert len(trimmed) == limit
+    # Keeps the most-recent entries
+    assert trimmed[-1]["id"] == f"id-{limit + 49}"
+
+
+def test_trim_queue_prefers_unposted(_cursor_env):
+    """When over the limit, _trim_queue keeps un-posted entries over older posted ones."""
+    _trim_queue = _POST["_trim_queue"]
+    limit = _POST["QUEUE_LIMIT"]
+    posted = [_make_queue_entry(f"p{i}", posted={"feed": "ok", "bluesky": "ok"}, entry_id=f"p-{i}")
+              for i in range(limit)]
+    unposted = [_make_queue_entry(f"u{i}", posted={"feed": None, "bluesky": None}, entry_id=f"u-{i}")
+                for i in range(5)]
+    trimmed = _trim_queue(posted + unposted)
+    assert len(trimmed) == limit
+    kept_ids = {e["id"] for e in trimmed}
+    # All un-posted entries survive even though they are newest and the queue is full
+    for u in unposted:
+        assert u["id"] in kept_ids
+
+
+def test_append_queue_enforces_limit(_cursor_env):
+    """_append_queue writes new entries and never lets the file exceed QUEUE_LIMIT."""
+    _append_queue = _POST["_append_queue"]
+    limit = _POST["QUEUE_LIMIT"]
+    # Seed the queue at the limit, all posted.
+    seed = [_make_queue_entry(f"s{i}", posted={"feed": "ok", "bluesky": "ok"}, entry_id=f"s-{i}")
+            for i in range(limit)]
+    (_cursor_env / "post_queue.jsonl").write_text("".join(json.dumps(e) + "\n" for e in seed))
+
+    new = [_make_queue_entry(f"n{i}", posted={"feed": None, "bluesky": None}, entry_id=f"n-{i}")
+           for i in range(10)]
+    _append_queue(new)
+
+    saved = _load_queue()
+    assert len(saved) <= limit
+    saved_ids = {e["id"] for e in saved}
+    # The freshly-appended (un-posted) entries are retained
+    for n in new:
+        assert n["id"] in saved_ids
 
 
 @patch.dict(os.environ, {"PX_POST_QA": "0"})

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -630,6 +630,27 @@ def test_append_queue_enforces_limit(_cursor_env):
 
 
 @patch.dict(os.environ, {"PX_POST_QA": "0"})
+def test_flush_stops_early_on_shutdown(_cursor_env):
+    """flush_queue honours a should_stop signal so SIGTERM stays responsive mid-flush."""
+    tmp = _cursor_env
+    queue_file = tmp / "post_queue.jsonl"
+    lines = [json.dumps(_make_queue_entry(thought=f"t{i}", entry_id=f"stop-{i:03d}"))
+             for i in range(5)]
+    queue_file.write_text("\n".join(lines) + "\n")
+
+    bsky = MagicMock()
+    bsky.post.return_value = "ok"
+
+    # Shutdown already requested: flush should do no feed writes and bail.
+    result = flush_queue(bsky, dry=True, should_stop=lambda: True)
+    assert result["processed"] == 0
+    bsky.post.assert_not_called()
+    # Nothing was marked posted
+    for line in queue_file.read_text().splitlines():
+        assert json.loads(line)["posted"]["feed"] is None
+
+
+@patch.dict(os.environ, {"PX_POST_QA": "0"})
 def test_flush_empty_queue_returns_dict(_cursor_env):
     """flush_queue() on an empty queue returns a dict with processed: 0."""
     tmp = _cursor_env


### PR DESCRIPTION
## Problem

`px-post` pegged a full CPU core continuously (journal: one run **"Consumed 1d 15h CPU time"**) and ignored `SIGTERM` — every `systemctl stop` timed out and got `SIGKILL`ed. Discovered after the Pi came back from a few days offline.

## Root cause (a feedback loop of three bugs)

Confirmed with live `py-spy` stack dumps (both inside the `for entry in new_thoughts` loop, in `_load_queue`→`json.loads` and `is_duplicate`→`difflib`):

1. **Cursor replayed the entire 10k-line backlog on every rotation.** `poll_new_thoughts()` tracked a **byte offset** against `thoughts-spark.jsonl`, which `px-mind` rewrites atomically as a rolling 10k-line window. Each rewrite changed the inode and usually shrank the file below the saved offset → `"reset to 0"` → all 10k lines re-read as "new" every poll.
2. **Per-entry O(N²) queue handling.** For each of those 10k entries, `queue_thought()` called `_load_queue()`, re-parsing the entire `post_queue.jsonl` — which had grown to **9,300 entries / 4MB** because `QUEUE_LIMIT` (200) was only enforced on flush, never on append. ~40GB of JSON parsing per rotation event.
3. **The loops never checked `_shutdown`,** so `SIGTERM` was deferred until the (never-completing) work finished. The watchdog couldn't fire either — `last_cycle` only updated *after* the loop.

Independently reviewed by codex, hermes, and agy — all confirmed the analysis and fix direction.

## Fix

- **Timestamp-based cursor** (tracks last processed `ts`), immune to atomic rewrites / rolling-window truncation. Fresh / legacy-offset / corrupt cursor records position **without replaying history** (use `--backfill` to seed the feed intentionally).
- **Queue loaded once per cycle** and appended in a single batched write; `QUEUE_LIMIT` enforced on append via `_trim_queue`, which prefers keeping **un-posted** entries over older posted ones.
- **`_shutdown` checked in both the poll loop and `flush_queue`** (both passes), so stops stay responsive even with a full queue where each entry can spend seconds in the QA gate; `last_cycle` refreshed every 100 entries.

## Tests

- Rewrote cursor tests for the ts-based contract, including a **regression test** that an atomic rewrite + shrink returns only genuinely-new entries.
- Added `_trim_queue` / `_append_queue` cap tests and a `flush_queue` early-shutdown test.
- Full suite: **694 passed, 3 skipped**.

## Verified live on the Pi

Deployed to `picar.local` and confirmed: cursor migrated to ts-based with no replay; px-post idle in `_shutdown.wait`; queue bounded; `systemctl stop` now exits cleanly in seconds (was 90s timeout → SIGKILL); **load 8.1 → 2.1, CPU temp 74°C → 66°C**. Pre-PR mitigation (queue trim + cursor reset) was also applied to stop the live burn.

https://claude.ai/code/session_01X4ZsVLbAq1Ab1XT2pSoMUR