### PR TITLE
fix(state): initialize robot_name so MCP status isn't always blank

### DIFF
--- a/src/pxh/state.py
+++ b/src/pxh/state.py
@@ -169,6 +169,8 @@ def default_state() -> Dict[str, Any]:
         "persona": None,
         "listening": False,
         "listening_since": None,
+        # Robot's name — Obi calls it Spark (consumed by mcp_server status)
+        "robot_name": "Spark",
         # SPARK child-companion fields
         "obi_routine": None,
         "obi_step": 0,

--- a/state/session.template.json
+++ b/state/session.template.json
@@ -16,6 +16,7 @@
   "persona": null,
   "listening": false,
   "listening_since": null,
+  "robot_name": "Spark",
   "obi_routine": null,
   "obi_step": 0,
   "obi_mood": null,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -67,6 +67,19 @@ def test_default_state_contains_tracking_fields(tmp_path, monkeypatch):
     assert all(key in loaded for key in expected_keys)
 
 
+def test_default_state_includes_robot_name(tmp_path, monkeypatch):
+    """robot_name is consumed by mcp_server status; it must be initialised
+    in both default_state() and the on-disk template (ensure_session prefers
+    the template) so it is never the empty string in a real session."""
+    session_file = tmp_path / "session.json"
+    monkeypatch.setenv("PX_SESSION_PATH", str(session_file))
+    assert state.default_state()["robot_name"] == "Spark"
+    # ensure_session writes from the repo template — robot_name must round-trip
+    state.ensure_session()
+    loaded = json.loads(session_file.read_text())
+    assert loaded["robot_name"] == "Spark"
+
+
 # -- tail_lines (issue #140) --
 
 def test_tail_lines_returns_last_n(tmp_path):


### PR DESCRIPTION
## What

`robot_name` is read by the MCP server's `spark_status` tool (`src/pxh/mcp_server.py:75`) but was never present in `default_state()` or `state/session.template.json`, so in any real session it resolved to the empty-string default. Initializes it to **"Spark"** (the name Obi uses) in both places — `ensure_session()` prefers the template, with `default_state()` as the fallback path.

## Why

Found while auditing #25. The Obi child-companion feature turned out to be **~90% already shipped** (April) but never checked off: the `spark` persona prompt, `bin/px-spark` launcher, and the `tool-routine/checkin/celebrate/breathe/transition/quiet/story` tools all exist, are wired into `voice_loop.py`, and have tests. `robot_name` was the single genuinely-uninitialized field — a latent dead-field bug in the MCP status output.

## Tests

TDD: `test_default_state_includes_robot_name` covers both the `default_state()` dict and the template round-trip through `ensure_session()`. Full non-live suite green: **696 passed, 3 skipped**.

## Related

Groomed #25 to reflect what's actually shipped (proposed for close). Remaining ambitions split into #161 (conversation memory) and #162 (autonomous coding).

https://claude.ai/code/session_01X4ZsVLbAq1Ab1XT2pSoMUR