### PR TITLE
feat(voice): rolling per-persona conversation buffer (#161)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ track.png
 state/notes.jsonl
 state/notes-*.jsonl
 state/notes.jsonl.vixen-backup
+state/conversation-*.jsonl
 state/awareness.json
 state/thoughts.jsonl
 state/thoughts-*.jsonl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ Three backends, same `pxh.voice_loop` core:
 
 Loop: wait for `listening: true` → build prompt (system + session + transcript + thoughts) → call LLM subprocess → parse last JSON `{tool, params}` → `validate_action()` → `execute_tool()` → update session. Override via `CODEX_CHAT_CMD`.
 
+**Conversation buffer**: each turn is appended to `state/conversation-{persona}.jsonl` (rolling window, `PX_CONVERSATION_TURNS`, default 10) and injected back into the next prompt as a "Recent conversation" section — gives SPARK short-term memory across turns without relying solely on file-injected session state. Per-persona file so GREMLIN/VIXEN/Spark histories never bleed. SPARK's utterance is the action's `params.text`, falling back to `(tool_name)` for non-speech actions.
+
 ### Wake Word System
 
 ```bash

--- a/src/pxh/voice_loop.py
+++ b/src/pxh/voice_loop.py
@@ -174,8 +174,11 @@ def _state_dir() -> Path:
 
 
 def conversation_path(persona: str) -> Path:
-    """Per-persona buffer file. Keeps GREMLIN/VIXEN/Spark histories isolated."""
-    slug = (persona or "default").lower().strip() or "default"
+    """Per-persona buffer file. Keeps GREMLIN/VIXEN/Spark histories isolated.
+    The slug is sanitized to a safe filename charset so a hostile persona value
+    can never escape the flat state-dir namespace (path traversal)."""
+    import re
+    slug = re.sub(r"[^a-z0-9_-]", "", (persona or "").lower().strip()) or "default"
     return _state_dir() / f"conversation-{slug}.jsonl"
 
 
@@ -207,7 +210,11 @@ def record_conversation_turn(
     spark_text: str,
     max_turns: int = CONVERSATION_MAX_TURNS,
 ) -> None:
-    """Append a turn and trim the buffer to the last max_turns, atomically."""
+    """Append a turn and trim the buffer to the last max_turns, atomically.
+    max_turns <= 0 disables the buffer (writes an empty file)."""
+    if max_turns <= 0:
+        atomic_write(conversation_path(persona), "")
+        return
     turns = recent_conversation(persona, n=max_turns + 1)
     turns.append({"user": user_text, "spark": spark_text})
     turns = turns[-max_turns:]
@@ -380,15 +387,15 @@ def build_model_prompt(system_prompt: str, state: Dict[str, Any], user_text: str
         context_sections.append("Recent events:")
         context_sections.append(json.dumps(recent_events, indent=2))
 
+    _active_persona = (state.get("persona") or "").lower().strip()
+
     # Rolling conversation memory (issue #161) — what was just said, per persona.
-    _conv_persona = (state.get("persona") or "").lower().strip()
-    recent_turns = recent_conversation(_conv_persona)
+    recent_turns = recent_conversation(_active_persona)
     if recent_turns:
         context_sections.append("Recent conversation (oldest first):")
         context_sections.append(json.dumps(recent_turns, indent=2))
 
     # Inject inner thoughts from px-mind — use persona-scoped file to prevent cross-persona leakage
-    _active_persona = (state.get("persona") or "").lower().strip()
     _thoughts_name = f"thoughts-{_active_persona}.jsonl" if _active_persona else "thoughts.jsonl"
     thoughts_file = Path(os.environ.get("PX_STATE_DIR", str(PROJECT_ROOT / "state"))) / _thoughts_name
     if thoughts_file.exists():

--- a/src/pxh/voice_loop.py
+++ b/src/pxh/voice_loop.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Optional, Tuple
 from pxh.utils import clamp
 
 from .logging import log_event
-from .state import load_session, update_session, ensure_session, tail_lines
+from .state import load_session, update_session, ensure_session, tail_lines, atomic_write
 from .time import utc_timestamp
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -161,6 +161,58 @@ PERSONA_VOICE_ENV = {
         "PX_VOICE_RATE": "100",
     },
 }
+
+
+# Rolling per-persona conversation memory (issue #161). Lets SPARK remember
+# the last few turns without relying entirely on file-injected session state —
+# e.g. coaching a routine without losing the thread between turns.
+CONVERSATION_MAX_TURNS = int(os.environ.get("PX_CONVERSATION_TURNS", "10"))
+
+
+def _state_dir() -> Path:
+    return Path(os.environ.get("PX_STATE_DIR", str(PROJECT_ROOT / "state")))
+
+
+def conversation_path(persona: str) -> Path:
+    """Per-persona buffer file. Keeps GREMLIN/VIXEN/Spark histories isolated."""
+    slug = (persona or "default").lower().strip() or "default"
+    return _state_dir() / f"conversation-{slug}.jsonl"
+
+
+def recent_conversation(persona: str, n: int = CONVERSATION_MAX_TURNS) -> list:
+    """Return up to the last n {user, spark} turns for this persona, oldest first."""
+    path = conversation_path(persona)
+    if not path.exists():
+        return []
+    turns = []
+    for line in tail_lines(path, n=n):
+        try:
+            turns.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return turns
+
+
+def conversation_spark_text(action: Dict[str, Any], tool: str) -> str:
+    """SPARK's utterance for the buffer: the spoken/typed text if the action
+    carries one, else a compact descriptor of what it did (e.g. '(tool_forward)')."""
+    params = action.get("params") or {}
+    text = (params.get("text") or "").strip()
+    return text if text else f"({tool})"
+
+
+def record_conversation_turn(
+    persona: str,
+    user_text: str,
+    spark_text: str,
+    max_turns: int = CONVERSATION_MAX_TURNS,
+) -> None:
+    """Append a turn and trim the buffer to the last max_turns, atomically."""
+    turns = recent_conversation(persona, n=max_turns + 1)
+    turns.append({"user": user_text, "spark": spark_text})
+    turns = turns[-max_turns:]
+    body = "".join(json.dumps(t, ensure_ascii=False) + "\n" for t in turns)
+    atomic_write(conversation_path(persona), body)
 
 
 class VoiceLoopError(Exception):
@@ -327,6 +379,13 @@ def build_model_prompt(system_prompt: str, state: Dict[str, Any], user_text: str
     if recent_events:
         context_sections.append("Recent events:")
         context_sections.append(json.dumps(recent_events, indent=2))
+
+    # Rolling conversation memory (issue #161) — what was just said, per persona.
+    _conv_persona = (state.get("persona") or "").lower().strip()
+    recent_turns = recent_conversation(_conv_persona)
+    if recent_turns:
+        context_sections.append("Recent conversation (oldest first):")
+        context_sections.append(json.dumps(recent_turns, indent=2))
 
     # Inject inner thoughts from px-mind — use persona-scoped file to prevent cross-persona leakage
     _active_persona = (state.get("persona") or "").lower().strip()
@@ -982,6 +1041,15 @@ def supervisor_loop(args: argparse.Namespace) -> None:
             transcript_entry["voice_result"] = voice_result
 
         log_event("voice-transcript", transcript_entry)
+
+        # Record the turn into the rolling per-persona conversation buffer (#161)
+        # so the next prompt carries what was just said.
+        try:
+            record_conversation_turn(
+                active_persona, user_text, conversation_spark_text(action, tool)
+            )
+        except Exception:
+            print("[voice-loop] failed to record conversation turn", file=sys.stderr)
 
         if args.exit_on_stop and tool == "tool_stop" and rc_tool == 0:
             print("[voice-loop] Stop command acknowledged. Exiting loop.")

--- a/tests/test_conversation_buffer.py
+++ b/tests/test_conversation_buffer.py
@@ -76,3 +76,23 @@ def test_spark_utterance_falls_back_to_tool_name_when_no_text():
 
 def test_spark_utterance_handles_missing_params():
     assert voice_loop.conversation_spark_text({"tool": "tool_stop"}, "tool_stop") == "(tool_stop)"
+
+
+def test_conversation_path_is_filename_safe(conv_state_dir):
+    """A persona value must never escape the flat state-dir namespace."""
+    path = voice_loop.conversation_path("../../etc/passwd")
+    assert path.parent == conv_state_dir
+    assert "/" not in path.name and ".." not in path.name
+
+
+def test_record_with_unsafe_persona_stays_in_state_dir(conv_state_dir):
+    voice_loop.record_conversation_turn("../../evil", "u", "s")
+    # nothing written outside the isolated state dir
+    assert not (conv_state_dir.parent.parent / "evil").exists()
+    # and it round-trips under the sanitized slug
+    assert voice_loop.recent_conversation("../../evil") == [{"user": "u", "spark": "s"}]
+
+
+def test_max_turns_zero_disables_buffer(conv_state_dir):
+    voice_loop.record_conversation_turn("spark", "u", "s", max_turns=0)
+    assert voice_loop.recent_conversation("spark") == []

--- a/tests/test_conversation_buffer.py
+++ b/tests/test_conversation_buffer.py
@@ -1,0 +1,78 @@
+"""Tests for the rolling per-persona conversation buffer (issue #161).
+
+SPARK should remember the last few turns of a conversation so it can coach
+a routine without relying entirely on file-injected session state. The buffer
+is per-persona (so GREMLIN/VIXEN/Spark histories never bleed into each other)
+and trimmed to a fixed window.
+"""
+
+import pytest
+
+from pxh import voice_loop
+
+
+@pytest.fixture
+def conv_state_dir(tmp_path, monkeypatch):
+    """Redirect the conversation buffer to an isolated state dir in-process."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    monkeypatch.setenv("PX_STATE_DIR", str(state_dir))
+    return state_dir
+
+
+def test_record_and_read_single_turn(conv_state_dir):
+    voice_loop.record_conversation_turn("spark", "where are my shoes", "By the front door.")
+    turns = voice_loop.recent_conversation("spark")
+    assert turns == [{"user": "where are my shoes", "spark": "By the front door."}]
+
+
+def test_buffer_trims_to_max_turns(conv_state_dir):
+    for i in range(15):
+        voice_loop.record_conversation_turn("spark", f"u{i}", f"s{i}", max_turns=10)
+    turns = voice_loop.recent_conversation("spark")
+    assert len(turns) == 10
+    # oldest five dropped; newest kept in order
+    assert turns[0]["user"] == "u5"
+    assert turns[-1]["user"] == "u14"
+
+
+def test_buffer_is_per_persona(conv_state_dir):
+    voice_loop.record_conversation_turn("spark", "spark question", "spark answer")
+    voice_loop.record_conversation_turn("gremlin", "gremlin question", "gremlin answer")
+    spark_turns = voice_loop.recent_conversation("spark")
+    gremlin_turns = voice_loop.recent_conversation("gremlin")
+    assert spark_turns == [{"user": "spark question", "spark": "spark answer"}]
+    assert gremlin_turns == [{"user": "gremlin question", "spark": "gremlin answer"}]
+
+
+def test_recent_conversation_empty_when_no_history(conv_state_dir):
+    assert voice_loop.recent_conversation("spark") == []
+
+
+def test_build_prompt_includes_recent_conversation(conv_state_dir):
+    voice_loop.record_conversation_turn("spark", "I like octopuses", "Three hearts, right?")
+    state = {"persona": "spark", "history": []}
+    prompt = voice_loop.build_model_prompt("SYS", state, "tell me more")
+    assert "Recent conversation" in prompt
+    assert "I like octopuses" in prompt
+    assert "Three hearts, right?" in prompt
+
+
+def test_build_prompt_omits_section_when_no_history(conv_state_dir):
+    state = {"persona": "spark", "history": []}
+    prompt = voice_loop.build_model_prompt("SYS", state, "hello")
+    assert "Recent conversation" not in prompt
+
+
+def test_spark_utterance_uses_params_text():
+    action = {"tool": "tool_voice", "params": {"text": "Hi Obi, nice one."}}
+    assert voice_loop.conversation_spark_text(action, "tool_voice") == "Hi Obi, nice one."
+
+
+def test_spark_utterance_falls_back_to_tool_name_when_no_text():
+    action = {"tool": "tool_forward", "params": {"speed": 30}}
+    assert voice_loop.conversation_spark_text(action, "tool_forward") == "(tool_forward)"
+
+
+def test_spark_utterance_handles_missing_params():
+    assert voice_loop.conversation_spark_text({"tool": "tool_stop"}, "tool_stop") == "(tool_stop)"


### PR DESCRIPTION
## What

Gives SPARK short-term memory across turns. Each turn is appended to `state/conversation-{persona}.jsonl` (rolling window, `PX_CONVERSATION_TURNS`, default 10) and injected back into the next prompt as a **"Recent conversation"** section. Per-persona file so GREMLIN/VIXEN/Spark histories never bleed.

## Why

#36 Layer 2 (split out as #161). Until now the voice loop ran effectively stateless — a child-companion that forgets what it said two turns ago can't coach a routine or hold a thread. The buffer closes that gap via prompt injection, without touching the underlying CLI session model.

## How

- `record_conversation_turn()` — append + trim to window, atomic write
- `recent_conversation()` — read last N via `tail_lines`
- `conversation_spark_text()` — SPARK's utterance is the action's `params.text`, falling back to `(tool_name)` for non-speech actions
- `build_model_prompt()` injects the section only when history exists
- supervisor loop records each completed turn (failure-tolerant)
- runtime buffers gitignored; documented in CLAUDE.md

## Tests

TDD throughout — 9 tests in `tests/test_conversation_buffer.py`: record/read, trim-to-window, per-persona isolation, prompt injection on/off, utterance extraction. Full non-live suite: **705 passed, 3 skipped**.

Closes #161.

https://claude.ai/code/session_01X4ZsVLbAq1Ab1XT2pSoMUR