### PR TITLE
feat: conversational self-evolution (#162)

### DIFF
--- a/bin/px-evolve
+++ b/bin/px-evolve
@@ -39,6 +39,7 @@ import threading
 import time
 from pathlib import Path
 
+from pxh.evolve_queue import build_pr_body, reset_building_to_pending
 
 PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", Path(__file__).parent.parent))
 LOG_DIR = Path(os.environ.get("LOG_DIR", PROJECT_ROOT / "logs"))
@@ -294,6 +295,8 @@ def process_entry(entry: dict, *, dry: bool = False) -> str:
     entry_id = entry["id"]
     intent = entry.get("intent", "")
     introspection = entry.get("introspection", {})
+    requester = entry.get("requester", "adrian")
+    source = entry.get("source", "cli")
 
     safe_id = re.sub(r"[^a-zA-Z0-9_-]", "-", entry_id)[:64]
     branch = f"spark/evolve-{safe_id}"
@@ -313,7 +316,7 @@ def process_entry(entry: dict, *, dry: bool = False) -> str:
         return "failed:worktree"
 
     try:
-        return _run_in_worktree(entry_id, intent, introspection, branch, workdir, dry=dry)
+        return _run_in_worktree(entry_id, intent, introspection, branch, workdir, dry=dry, requester=requester, source=source)
     finally:
         # 8. Cleanup worktree
         _cleanup_worktree(workdir, entry_id)
@@ -322,6 +325,7 @@ def process_entry(entry: dict, *, dry: bool = False) -> str:
 def _run_in_worktree(
     entry_id: str, intent: str, introspection: dict,
     branch: str, workdir: str, *, dry: bool,
+    requester: str = "adrian", source: str = "cli",
 ) -> str:
     """4-phase evolution: plan (Opus) → implement (Sonnet) → test (Haiku) → QA (Sonnet)."""
     if dry:
@@ -523,13 +527,7 @@ def _run_in_worktree(
 
     # 8. Create PR
     intent_summary = intent[:60].replace('"', "'")
-    body = (
-        f"## Summary\n"
-        f"SPARK self-evolution: {intent}\n\n"
-        f"## Changed files\n"
-        + "\n".join(f"- `{f}`" for f in changed_files)
-        + "\n\n---\n*Proposed autonomously by SPARK via px-evolve.*"
-    )
+    body = build_pr_body(intent, changed_files, requester=requester, source=source)
 
     try:
         subprocess.run(
@@ -627,6 +625,9 @@ def _update_entry_in_queue(entry_id: str, **fields) -> None:
 
 def run_once(*, dry: bool) -> int:
     """Process all pending entries. Returns count processed."""
+    n = reset_building_to_pending()
+    if n:
+        log(f"reset {n} stale 'building' entries to pending")
     entries = load_queue()
     if not entries:
         return 0
@@ -639,6 +640,7 @@ def run_once(*, dry: bool) -> int:
             _update_entry_in_queue(entry["id"], status="skipped:dry")
             continue
 
+        _update_entry_in_queue(entry["id"], status="building")
         raw_status = process_entry(entry, dry=dry)
         ts_now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -667,6 +669,8 @@ def run_once(*, dry: bool) -> int:
             "intent": entry.get("intent", ""),
             "status": status,
             "ts_completed": ts_now,
+            "requester": entry.get("requester", "adrian"),
+            "source": entry.get("source", "cli"),
         }
         if pr_url:
             log_entry["pr_url"] = pr_url

--- a/bin/tool-evolve
+++ b/bin/tool-evolve
@@ -10,29 +10,13 @@ from __future__ import annotations
 
 import json
 import os
-import random
-import time
-from datetime import datetime, timezone
 from pathlib import Path
 
-from pxh.state import atomic_write
-
-try:
-    from filelock import FileLock as _FL
-except ImportError:
-    _FL = None
+from pxh.evolve_queue import enqueue_evolve, EvolveQuotaError, EvolvePendingError
 
 # ── Paths ──────────────────────────────────────────────────────────
 PROJECT_ROOT = Path(os.environ["PROJECT_ROOT"])
 STATE_DIR    = Path(os.environ.get("PX_STATE_DIR", PROJECT_ROOT / "state"))
-
-INTROSPECT_FILE  = STATE_DIR / "introspection.json"
-EVOLVE_QUEUE     = STATE_DIR / "evolve_queue.jsonl"
-EVOLVE_LOG       = STATE_DIR / "evolve_log.jsonl"
-
-MAX_INTROSPECT_AGE_S = 3600   # introspection must be < 1 hour old
-MIN_INTENT_LEN       = 20     # intent must be at least 20 chars
-RATE_LIMIT_S         = 86400  # max 1 evolution per 24 hours
 
 
 def error(msg: str) -> int:
@@ -42,82 +26,17 @@ def error(msg: str) -> int:
 
 def main() -> int:
     intent = os.environ.get("PX_EVOLVE_INTENT", "").strip()
-    dry = os.environ.get("PX_DRY", "0") == "1"
 
-    # ── Validate introspection exists and is fresh ─────────────────
-    if not INTROSPECT_FILE.exists():
-        return error("introspect first")
-
-    age_s = time.time() - INTROSPECT_FILE.stat().st_mtime
-    if age_s > MAX_INTROSPECT_AGE_S:
-        return error("introspect first")
-
-    # ── Validate intent length ─────────────────────────────────────
-    if len(intent) < MIN_INTENT_LEN:
-        return error("intent too vague")
-
-    # ── 24h rate limit ─────────────────────────────────────────────
-    if EVOLVE_LOG.exists():
-        now = time.time()
-        for line in EVOLVE_LOG.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-                # Prefer numeric ts (epoch), fall back to ts_completed (ISO string)
-                ts_raw = entry.get("ts")  # numeric epoch from our fix
-                if ts_raw is None or not isinstance(ts_raw, (int, float)):
-                    ts_raw = entry.get("ts_completed", "")
-                if isinstance(ts_raw, str) and ts_raw:
-                    ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00")).timestamp()
-                elif isinstance(ts_raw, (int, float)):
-                    ts = float(ts_raw)
-                else:
-                    continue  # unparseable — skip this entry
-                # Only count successful evolutions (pr_created) against rate limit
-                # Failed attempts shouldn't block the next try
-                status = entry.get("status", "")
-                if status == "pr_created" and now - ts < RATE_LIMIT_S:
-                    return error("rate limit: max 1 evolution per 24 hours")
-            except (json.JSONDecodeError, TypeError, ValueError, OverflowError):
-                continue
-
-    # ── Load introspection ─────────────────────────────────────────
     try:
-        introspection = json.loads(INTROSPECT_FILE.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return error("introspect first")
+        entry = enqueue_evolve(intent, requester="adrian", source="cli")
+    except ValueError as e:
+        return error(str(e))
+    except EvolveQuotaError:
+        return error("rate limit: max 1 evolution per 24 hours")
+    except EvolvePendingError:
+        return error("a request is already pending")
 
-    # ── Generate ID ────────────────────────────────────────────────
-    now_dt = datetime.now(timezone.utc)
-    nnn = random.randint(0, 999)
-    evolve_id = f"evolve-{now_dt.strftime('%Y%m%d-%H%M%S')}-{nnn:03d}"
-
-    # ── Build queue entry ──────────────────────────────────────────
-    queue_entry = {
-        "ts": now_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "id": evolve_id,
-        "intent": intent,
-        "introspection": introspection,
-        "status": "pending",
-    }
-
-    # ── Append to queue ────────────────────────────────────────────
-    if dry:
-        queue_entry["dry"] = True
-
-    _lock = _FL(str(EVOLVE_QUEUE) + ".lock", timeout=5) if _FL else None
-    ctx = _lock if _lock else __import__("contextlib").nullcontext()
-    with ctx:
-        existing = ""
-        if EVOLVE_QUEUE.exists():
-            existing = EVOLVE_QUEUE.read_text(encoding="utf-8")
-            if existing and not existing.endswith("\n"):
-                existing += "\n"
-        atomic_write(EVOLVE_QUEUE, existing + json.dumps(queue_entry) + "\n")
-
-    print(json.dumps({"status": "queued", "id": evolve_id}))
+    print(json.dumps({"status": "queued", "id": entry["id"]}))
     return 0
 
 

--- a/docs/superpowers/plans/2026-06-20-obi-session-batch.md
+++ b/docs/superpowers/plans/2026-06-20-obi-session-batch.md
@@ -1,0 +1,1839 @@
+# Obi Session Batch — Implementation Plan (#26, #33, #34, #38, #36 L1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship five GitHub-issue features in one session: Custom Sound Effects (#26), Obi's Dopamine Menu items (#33), Sleep Mode (#34), the web Settings panel (#38), and full-tool MCP exposure (#36 Layer 1).
+
+**Architecture:** Each feature follows the established SPARK tool/loop/state patterns. New `bin/tool-*` scripts emit one JSON line and gate on `PX_DRY`; voice-loop registration goes through `ALLOWED_TOOLS`/`TOOL_COMMANDS`/`validate_action`; session flags flow through `state.default_state()` + `api.PATCHABLE_FIELDS`; the MCP server reuses `validate_action`+`execute_tool` rather than duplicating dispatch.
+
+**Tech Stack:** Python 3.11 (bin scripts run under `/usr/bin/python3`, library under `.venv`), bash heredocs, FastAPI (`api.py`, single worker), FastMCP (`mcp==1.27.1`), pytest, espeak/aplay/arecord, FileLock.
+
+## Global Constraints
+
+- **TDD always.** Write the failing test, watch it fail, minimal code to pass, commit. Never write impl before a red test.
+- **Every tool emits exactly one JSON object** as the last stdout line; tests parse via `parse_json` = `json.loads(output.splitlines()[-1])`.
+- **Every tool supports `PX_DRY=1`** (skips motion/audio/recording) and reports `{"dry": true|false}`; errors are `{"status": "error", "error": "..."}`.
+- **`FileLock` is not reentrant** — `update_session` calls `ensure_session()` *before* the lock. Don't nest locks.
+- **Motion gating** is enforced inside each motion `bin/tool-*` (returns rc=2, `{"status":"blocked"}`); never bypass it.
+- **Night silence** is unconditional 19:00–07:00 Hobart (`mind._is_night_silence`); Sleep Mode is *additional*, user-initiated, and works outside that window.
+- **Tests use the `isolated_project` fixture** (`tests/conftest.py`) — copy `["env"]`, set `PX_DRY=1`, run via `run_tool(["bin/tool-x"], env)`.
+- **New tools must be added in 6 places** (CLAUDE.md "Adding a New Tool"): `bin/tool-*`, `ALLOWED_TOOLS`, `TOOL_COMMANDS`, `validate_action`, the four prompt docs, and a dry-run test.
+- **Commit after every green task.** End commit messages with `Claude-Session: https://claude.ai/code/session_01SWw4QW6bzbv3gQWphrcV8E`.
+- **Staging:** never `git add -A`; stage explicit paths (untracked artifacts live in repo root).
+- Run `python -m pytest -q` (Pi suite) before each commit touching library code; `m5/announce-relay` is unaffected by this plan.
+
+## Recommended Execution Order
+
+Part A (#26) → Part B (#33) → Part C (#34) → Part D (#38) → Part E (#36 L1). A/B are independent quick wins; C adds the `spark_sleep_mode` flag that D's Settings panel surfaces; D's session-voice persistence and C's amplitude flag both touch `tool-voice` (do C's amplitude first); E reuses the registry the earlier parts extend, so it runs last and picks up the new tools for free.
+
+---
+
+## File Structure
+
+**Part A — #26 Custom Sound Effects**
+- Modify: `bin/tool-play-sound` (dynamic allowlist from `sounds/`, `PX_SOUNDS_DIR` test seam)
+- Create: `bin/tool-record-sound` (record N s → `sounds/<name>.wav`)
+- Modify: `src/pxh/voice_loop.py` (register `tool_record_sound`; ensure `tool_play_sound` validate branch passes name)
+- Modify: `docs/prompts/{claude,codex}-voice-system.md`, `docs/prompts/persona-{gremlin,vixen}.md`
+- Test: `tests/test_tools.py`
+
+**Part B — #33 Dopamine Menu items**
+- Modify: `bin/tool-dopamine-menu` (`add` action writes tagged note; suggest path merges Obi items)
+- Modify: `src/pxh/voice_loop.py` (`validate_action` branch for `tool_dopamine_menu` params)
+- Modify: prompt docs
+- Test: `tests/test_tools.py`
+
+**Part C — #34 Sleep Mode**
+- Modify: `src/pxh/state.py` (`default_state` adds `spark_sleep_mode`), `state/session.template.json`
+- Create: `bin/tool-sleep` (start|check|end)
+- Modify: `bin/tool-voice` (`PX_VOICE_AMPLITUDE` → espeak `-a`; echo in dry payload)
+- Modify: `src/pxh/mind.py` (`expression()` sleep suppression + amplitude injection)
+- Modify: `bin/px-wake-listen` (whisper onset via `_effective_onset_rms` helper + env overrides)
+- Modify: `src/pxh/api.py` (`SessionPatch` + `PATCHABLE_FIELDS` add `spark_sleep_mode`)
+- Modify: `src/pxh/voice_loop.py` + prompt docs (register `tool_sleep`)
+- Test: `tests/test_tools.py`, `tests/test_mind.py`, `tests/test_wake_listen.py` (new), `tests/test_api.py`
+
+**Part D — #38 Settings Panel**
+- Modify: `src/pxh/voice_loop.py` (`execute_tool` applies session voice fields as base)
+- Modify: `src/pxh/api.py` (`PATCH /api/v1/voice`, `POST /api/v1/voice/preview`, `GET /api/v1/config/backup`, `POST /api/v1/config/import`, `PATCH /api/v1/config`; dashboard Settings sub-tab)
+- Create: `src/pxh/runtime_config.py` (read/write `state/runtime_config.json` overrides)
+- Modify: `src/pxh/mind.py` (read runtime_config backend/model override at reflection start)
+- Test: `tests/test_api.py`, `tests/test_voice_loop.py`, `tests/test_runtime_config.py` (new)
+
+**Part E — #36 Layer 1 MCP expansion**
+- Create: `src/pxh/schemas.py` (`TOOL_SCHEMAS` declarative param spec)
+- Modify: `src/pxh/mcp_server.py` (`spark_list_tools`, `spark_run_tool` reusing validate/execute; `spark://` resources)
+- Modify: `requirements.txt` (add `mcp>=1.27`)
+- Test: `tests/test_schemas.py` (new), `tests/test_mcp_server.py`
+
+---
+
+# PART A — #26 Custom Sound Effects
+
+### Task A1: Dynamic sound allowlist in `tool-play-sound`
+
+**Files:**
+- Modify: `bin/tool-play-sound:20-23` (SOUNDS_DIR + ALLOWED_SOUNDS)
+- Modify: `bin/tool-play-sound:36-43` (validation against dynamic set)
+- Test: `tests/test_tools.py`
+
+**Interfaces:**
+- Produces: `tool-play-sound` accepts any `PX_SOUND` whose `<name>.wav` exists in the sounds dir (builtins ∪ recorded). Honors `PX_SOUNDS_DIR` override (defaults to `$PROJECT_ROOT/sounds`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_tools.py
+def test_tool_play_sound_allows_recorded_file(isolated_project, tmp_path):
+    sounds = tmp_path / "sounds"
+    sounds.mkdir()
+    (sounds / "obi-laugh.wav").write_bytes(b"RIFF0000WAVEfmt ")
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"
+    env["PX_SOUNDS_DIR"] = str(sounds)
+    env["PX_SOUND"] = "obi-laugh"
+    payload = parse_json(run_tool(["bin/tool-play-sound"], env))
+    assert payload["status"] == "ok"
+    assert payload["sound"] == "obi-laugh"
+
+
+def test_tool_play_sound_rejects_unknown(isolated_project, tmp_path):
+    sounds = tmp_path / "sounds"; sounds.mkdir()
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"; env["PX_SOUNDS_DIR"] = str(sounds); env["PX_SOUND"] = "nope"
+    payload = parse_json(run_tool(["bin/tool-play-sound"], env))
+    assert payload["status"] == "error"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_tools.py -k play_sound_allows_recorded -v`
+Expected: FAIL — `obi-laugh` not in the hardcoded `{"chime","beep","tada","alert"}`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `bin/tool-play-sound`, replace lines 20-23:
+
+```python
+PROJECT_ROOT = Path(os.environ["PROJECT_ROOT"])
+SOUNDS_DIR   = Path(os.environ.get("PX_SOUNDS_DIR", PROJECT_ROOT / "sounds"))
+
+# Built-in effects always allowed; recorded sounds are discovered from SOUNDS_DIR.
+BUILTIN_SOUNDS = {"chime", "beep", "tada", "alert"}
+
+
+def allowed_sounds() -> set[str]:
+    found = set()
+    if SOUNDS_DIR.exists():
+        found = {p.stem.lower() for p in SOUNDS_DIR.glob("*.wav")}
+    return BUILTIN_SOUNDS | found
+```
+
+Then replace the membership check (lines 36-43):
+
+```python
+    if name not in allowed_sounds():
+        payload = {
+            "status": "error",
+            "error": f"unknown sound '{name}'; allowed: {sorted(allowed_sounds())}",
+        }
+        log_event("play_sound", payload)
+        print(json.dumps(payload))
+        return 1
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_tools.py -k play_sound -v`
+Expected: PASS (both new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/tool-play-sound tests/test_tools.py
+git commit -m "feat(sound): tool-play-sound discovers recorded sounds dynamically"
+```
+
+### Task A2: `bin/tool-record-sound`
+
+**Files:**
+- Create: `bin/tool-record-sound`
+- Test: `tests/test_tools.py`
+
+**Interfaces:**
+- Consumes: `PX_RECORD_NAME` (slug), `PX_RECORD_SECONDS` (1-15, default 5), `PX_SOUNDS_DIR`.
+- Produces: writes `<name>.wav` via `arecord`; dry-run skips recording. JSON `{status, name, seconds, path, dry}`. Name sanitised to `[a-z0-9-]` (lowercase, spaces→`-`); rejects empty/invalid.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_tools.py
+def test_tool_record_sound_dry_run(isolated_project, tmp_path):
+    sounds = tmp_path / "sounds"; sounds.mkdir()
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"; env["PX_SOUNDS_DIR"] = str(sounds)
+    env["PX_RECORD_NAME"] = "Obi Laugh!"; env["PX_RECORD_SECONDS"] = "3"
+    payload = parse_json(run_tool(["bin/tool-record-sound"], env))
+    assert payload["status"] == "ok"
+    assert payload["name"] == "obi-laugh"   # sanitised slug
+    assert payload["seconds"] == 3
+    assert payload["dry"] is True
+    # dry-run must NOT create a file
+    assert not (sounds / "obi-laugh.wav").exists()
+
+
+def test_tool_record_sound_requires_name(isolated_project, tmp_path):
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"; env["PX_SOUNDS_DIR"] = str(tmp_path / "sounds")
+    env["PX_RECORD_NAME"] = "   "
+    payload = parse_json(run_tool(["bin/tool-record-sound"], env))
+    assert payload["status"] == "error"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_tools.py -k record_sound -v`
+Expected: FAIL — `bin/tool-record-sound` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `bin/tool-record-sound` (chmod +x):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/px-env"
+
+python - "$@" <<'PY'
+"""Tool: record a short sound from the USB mic, save as a named effect."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+from pxh.logging import log_event
+from pxh.state import update_session
+
+PROJECT_ROOT = Path(os.environ["PROJECT_ROOT"])
+SOUNDS_DIR   = Path(os.environ.get("PX_SOUNDS_DIR", PROJECT_ROOT / "sounds"))
+
+
+def slugify(raw: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", raw.strip().lower()).strip("-")
+    return s[:40]
+
+
+def main() -> int:
+    dry = os.environ.get("PX_DRY", "0") != "0"
+    name = slugify(os.environ.get("PX_RECORD_NAME", ""))
+    try:
+        seconds = int(os.environ.get("PX_RECORD_SECONDS", "5"))
+    except ValueError:
+        seconds = 5
+    seconds = max(1, min(15, seconds))
+
+    if not name:
+        payload = {"status": "error", "error": "PX_RECORD_NAME is required"}
+        log_event("record_sound", payload); print(json.dumps(payload)); return 1
+    if name in {"chime", "beep", "tada", "alert"}:
+        payload = {"status": "error", "error": f"'{name}' is a built-in sound name"}
+        log_event("record_sound", payload); print(json.dumps(payload)); return 1
+
+    out_path = SOUNDS_DIR / f"{name}.wav"
+
+    if dry:
+        payload = {"status": "ok", "name": name, "seconds": seconds,
+                   "path": str(out_path), "dry": True}
+        log_event("record_sound", payload); print(json.dumps(payload)); return 0
+
+    SOUNDS_DIR.mkdir(parents=True, exist_ok=True)
+    device = os.environ.get("PX_RECORD_DEVICE", "")
+    cmd = ["arecord", "-q", "-f", "cd", "-d", str(seconds)]
+    if device:
+        cmd.extend(["-D", device])
+    cmd.append(str(out_path))
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except Exception as exc:
+        payload = {"status": "error", "error": f"arecord failed: {exc}"}
+        log_event("record_sound", payload); print(json.dumps(payload)); return 1
+    if result.returncode != 0:
+        payload = {"status": "error", "error": "arecord exited non-zero",
+                   "rc": result.returncode, "stderr": result.stderr[-512:]}
+        log_event("record_sound", payload); print(json.dumps(payload)); return 1
+
+    update_session(
+        fields={"last_action": "tool_record_sound"},
+        history_entry={"event": "record_sound", "name": name, "seconds": seconds},
+    )
+    payload = {"status": "ok", "name": name, "seconds": seconds,
+               "path": str(out_path), "dry": False}
+    log_event("record_sound", payload); print(json.dumps(payload)); return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `chmod +x bin/tool-record-sound && python -m pytest tests/test_tools.py -k record_sound -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/tool-record-sound tests/test_tools.py
+git commit -m "feat(sound): add tool-record-sound (record named effect from mic)"
+```
+
+### Task A3: Register `tool_record_sound` in the voice loop + prompts
+
+**Files:**
+- Modify: `src/pxh/voice_loop.py` (`ALLOWED_TOOLS`, `TOOL_COMMANDS`, `validate_action`)
+- Modify: `docs/prompts/{claude,codex}-voice-system.md`, `docs/prompts/persona-{gremlin,vixen}.md`
+- Test: `tests/test_voice_loop.py`
+
+**Interfaces:**
+- Consumes: `validate_action({"tool":"tool_record_sound","params":{"name":..,"seconds":..}})` → `("tool_record_sound", {"PX_RECORD_NAME":..,"PX_RECORD_SECONDS":..})`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_voice_loop.py
+def test_validate_record_sound():
+    from pxh.voice_loop import validate_action, ALLOWED_TOOLS
+    assert "tool_record_sound" in ALLOWED_TOOLS
+    tool, env = validate_action({"tool": "tool_record_sound",
+                                 "params": {"name": "Obi Laugh", "seconds": 3}})
+    assert tool == "tool_record_sound"
+    assert env["PX_RECORD_NAME"] == "Obi Laugh"
+    assert env["PX_RECORD_SECONDS"] == "3"
+
+
+def test_validate_record_sound_clamps_seconds():
+    from pxh.voice_loop import validate_action
+    _, env = validate_action({"tool": "tool_record_sound",
+                              "params": {"name": "x", "seconds": 99}})
+    assert env["PX_RECORD_SECONDS"] == "15"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_voice_loop.py -k record_sound -v`
+Expected: FAIL — `tool_record_sound` not in `ALLOWED_TOOLS`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/pxh/voice_loop.py` add `"tool_record_sound",` to `ALLOWED_TOOLS` (after `"tool_play_sound",`, line ~41) and to `TOOL_COMMANDS`:
+
+```python
+    "tool_record_sound":   BIN_DIR / "tool-record-sound",
+```
+
+Add a `validate_action` branch (near the `tool_play_sound` branch):
+
+```python
+    elif tool == "tool_record_sound":
+        name = params.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise VoiceLoopError("tool_record_sound requires a non-empty name")
+        sanitized["PX_RECORD_NAME"] = name.strip()[:60]
+        seconds = int(clamp(_num(params.get("seconds", 5), "seconds"), 1, 15))
+        sanitized["PX_RECORD_SECONDS"] = str(seconds)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_voice_loop.py -k record_sound -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update prompt docs**
+
+Add to `docs/prompts/claude-voice-system.md` and `codex-voice-system.md` (tool list) and both persona files, matching the existing bullet style:
+
+```markdown
+- tool_record_sound → Record a short sound from the mic and save it with a name Obi picks (params: name, seconds 1-15). Then play it with tool_play_sound.
+```
+
+Also update the `tool_play_sound` line in all four docs to note recorded sounds are allowed: `params: name — chime|beep|tada|alert, or any recorded sound`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pxh/voice_loop.py tests/test_voice_loop.py docs/prompts/
+git commit -m "feat(sound): register tool_record_sound in voice loop + prompts"
+```
+
+---
+
+# PART B — #33 Obi's Dopamine Menu items
+
+### Task B1: `add` action writes a tagged note; suggest path merges Obi items
+
+**Files:**
+- Modify: `bin/tool-dopamine-menu` (add `PX_DOPAMINE_ACTION`, tagged-note read/write)
+- Test: `tests/test_tools.py`
+
+**Interfaces:**
+- Consumes: `PX_DOPAMINE_ACTION` = `suggest` (default) | `add`; `PX_DOPAMINE_ITEM` (text, for add); existing `PX_DOPAMINE_ENERGY`, `PX_DOPAMINE_CONTEXT`.
+- Produces: on `add`, appends a note `"[dopamine-item:<energy>:<context>] <text>"` to the persona-scoped notes file; on `suggest`, the pick pool = builtin MENU[energy][context] ∪ Obi items tagged for that energy/context.
+- Tag format: `[dopamine-item:<energy>:<context>]` prefix on the note's `note` field (matches the `[mind]` prefix convention).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_tools.py
+def test_dopamine_add_then_suggest_includes_item(isolated_project):
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"
+    env["PX_DOPAMINE_ACTION"] = "add"
+    env["PX_DOPAMINE_ITEM"] = "Watching a volcano video"
+    env["PX_DOPAMINE_ENERGY"] = "low"
+    env["PX_DOPAMINE_CONTEXT"] = "free"
+    add = parse_json(run_tool(["bin/tool-dopamine-menu"], env))
+    assert add["status"] == "ok"
+    assert add["action"] == "add"
+
+    # the note file lives under the isolated state dir, shared persona scope
+    notes = (isolated_project["state_dir"] / "notes.jsonl").read_text()
+    assert "[dopamine-item:low:free] Watching a volcano video" in notes
+
+    env2 = isolated_project["env"].copy()
+    env2["PX_DRY"] = "1"
+    env2["PX_DOPAMINE_ENERGY"] = "low"; env2["PX_DOPAMINE_CONTEXT"] = "free"
+    # force the Obi item into the pick set by making it the only candidate path:
+    env2["PX_DOPAMINE_PICK_OBI_ONLY"] = "1"   # test seam
+    sug = parse_json(run_tool(["bin/tool-dopamine-menu"], env2))
+    assert "Watching a volcano video" in sug["picks"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_tools.py -k dopamine_add -v`
+Expected: FAIL — no `add` action; no tagged note written.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `bin/tool-dopamine-menu`, add imports and a notes path helper near the top of the heredoc:
+
+```python
+from pxh.state import load_session, update_session
+from pxh.time import utc_timestamp
+from filelock import FileLock
+
+STATE_DIR = Path(os.environ.get("PX_STATE_DIR", PROJECT_ROOT / "state"))
+
+
+def notes_file_for_persona(persona: str) -> Path:
+    return STATE_DIR / (f"notes-{persona}.jsonl" if persona else "notes.jsonl")
+
+
+def add_item(item: str, energy: str, context: str, persona: str) -> None:
+    notes_file = notes_file_for_persona(persona)
+    notes_file.parent.mkdir(parents=True, exist_ok=True)
+    record = {"ts": utc_timestamp(),
+              "note": f"[dopamine-item:{energy}:{context}] {item[:200]}"}
+    with FileLock(str(notes_file) + ".lock", timeout=10):
+        with notes_file.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+
+
+def obi_items(energy: str, context: str, persona: str) -> list[str]:
+    notes_file = notes_file_for_persona(persona)
+    if not notes_file.exists():
+        return []
+    prefix = f"[dopamine-item:{energy}:{context}]"
+    out = []
+    for line in notes_file.read_text(encoding="utf-8").strip().splitlines():
+        try:
+            note = json.loads(line).get("note", "")
+        except json.JSONDecodeError:
+            continue
+        if note.startswith(prefix):
+            out.append(note[len(prefix):].strip())
+    return out
+```
+
+Then in `main()`, branch on the action before the existing suggest logic:
+
+```python
+    action = os.environ.get("PX_DOPAMINE_ACTION", "suggest").lower()
+    persona = (load_session().get("persona") or "").lower().strip()
+
+    if action == "add":
+        item = os.environ.get("PX_DOPAMINE_ITEM", "").strip()
+        if not item:
+            payload = {"status": "error", "error": "PX_DOPAMINE_ITEM is required"}
+            log_event("dopamine_menu", payload); print(json.dumps(payload)); return 1
+        if not dry:
+            add_item(item, energy, context, persona)
+        speak(f"Added that to your menu. {energy} energy.", dry)
+        payload = {"status": "ok", "action": "add", "item": item,
+                   "energy": energy, "context": context, "dry": dry}
+        log_event("dopamine_menu", payload); print(json.dumps(payload)); return 0
+```
+
+And in the suggest path, merge Obi items into the pool before `random.sample`:
+
+```python
+    pool = list(MENU[energy][context])
+    extra = obi_items(energy, context, persona)
+    if os.environ.get("PX_DOPAMINE_PICK_OBI_ONLY") == "1" and extra:
+        pool = extra
+    else:
+        pool = pool + extra
+    picks = random.sample(pool, min(2, len(pool)))
+```
+
+(Note `energy`/`context` are validated against `MENU` *before* `add` so tags use canonical values — keep the existing fallback lines 112-115 above this block.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_tools.py -k dopamine -v`
+Expected: PASS (new + existing dopamine tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/tool-dopamine-menu tests/test_tools.py
+git commit -m "feat(dopamine): Obi can add his own menu items via tagged notes"
+```
+
+### Task B2: `validate_action` for dopamine add + prompts
+
+**Files:**
+- Modify: `src/pxh/voice_loop.py` (`validate_action` branch for `tool_dopamine_menu`)
+- Modify: prompt docs
+- Test: `tests/test_voice_loop.py`
+
+**Interfaces:**
+- Consumes: `validate_action({"tool":"tool_dopamine_menu","params":{"action":"add","item":..,"energy":..,"context":..}})`. `tool_dopamine_menu` is already in `ALLOWED_TOOLS`/`TOOL_COMMANDS`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_voice_loop.py
+def test_validate_dopamine_add():
+    from pxh.voice_loop import validate_action
+    tool, env = validate_action({"tool": "tool_dopamine_menu",
+        "params": {"action": "add", "item": "magnetic tiles",
+                   "energy": "high", "context": "free"}})
+    assert tool == "tool_dopamine_menu"
+    assert env["PX_DOPAMINE_ACTION"] == "add"
+    assert env["PX_DOPAMINE_ITEM"] == "magnetic tiles"
+    assert env["PX_DOPAMINE_ENERGY"] == "high"
+    assert env["PX_DOPAMINE_CONTEXT"] == "free"
+
+
+def test_validate_dopamine_add_requires_item():
+    import pytest
+    from pxh.voice_loop import validate_action, VoiceLoopError
+    with pytest.raises(VoiceLoopError):
+        validate_action({"tool": "tool_dopamine_menu",
+                         "params": {"action": "add"}})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_voice_loop.py -k dopamine -v`
+Expected: FAIL (no branch sets these env vars / no item check). If a permissive branch already exists, the `requires_item` test fails first.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add/replace the `tool_dopamine_menu` branch in `validate_action`:
+
+```python
+    elif tool == "tool_dopamine_menu":
+        action = str(params.get("action", "suggest")).lower()
+        if action not in ("suggest", "add"):
+            raise VoiceLoopError("tool_dopamine_menu action must be suggest|add")
+        sanitized["PX_DOPAMINE_ACTION"] = action
+        energy = str(params.get("energy", "medium")).lower()
+        context = str(params.get("context", "free")).lower()
+        if energy not in ("high", "medium", "low"):
+            raise VoiceLoopError(f"invalid energy '{energy}'")
+        if context not in ("free", "focus", "wind-down"):
+            raise VoiceLoopError(f"invalid context '{context}'")
+        sanitized["PX_DOPAMINE_ENERGY"] = energy
+        sanitized["PX_DOPAMINE_CONTEXT"] = context
+        if action == "add":
+            item = params.get("item")
+            if not isinstance(item, str) or not item.strip():
+                raise VoiceLoopError("tool_dopamine_menu add requires an item")
+            sanitized["PX_DOPAMINE_ITEM"] = item.strip()[:200]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_voice_loop.py -k dopamine -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update prompts + commit**
+
+Update the `tool_dopamine_menu` entry in all four prompt docs to mention `action: suggest|add, item (for add), energy: high|medium|low, context: free|focus|wind-down`.
+
+```bash
+git add src/pxh/voice_loop.py tests/test_voice_loop.py docs/prompts/
+git commit -m "feat(dopamine): validate add action params + document"
+```
+
+---
+
+# PART C — #34 Sleep Mode
+
+### Task C1: `spark_sleep_mode` session field
+
+**Files:**
+- Modify: `src/pxh/state.py` (`default_state`, near the `spark_quiet_mode` line ~180)
+- Modify: `state/session.template.json`
+- Test: `tests/test_state.py`
+
+**Interfaces:**
+- Produces: every session has `spark_sleep_mode: bool` (default `False`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_state.py
+def test_default_state_has_sleep_mode():
+    from pxh.state import default_state
+    assert default_state()["spark_sleep_mode"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_state.py -k sleep_mode -v`
+Expected: FAIL — KeyError.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/pxh/state.py` `default_state()`, add after the `spark_quiet_mode` entry:
+
+```python
+        "spark_sleep_mode": False,
+```
+
+In `state/session.template.json`, add `"spark_sleep_mode": false,` next to `"spark_quiet_mode"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_state.py -k sleep_mode -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/state.py state/session.template.json tests/test_state.py
+git commit -m "feat(sleep): add spark_sleep_mode session field"
+```
+
+### Task C2: `PX_VOICE_AMPLITUDE` in `tool-voice`
+
+**Files:**
+- Modify: `bin/tool-voice` (espeak invocation ~line 220; dry payload)
+- Test: `tests/test_tools.py`
+
+**Interfaces:**
+- Consumes: `PX_VOICE_AMPLITUDE` (0-200, default 100); clamped.
+- Produces: espeak called with `-a <amp>`; dry payload includes `"amplitude": <int>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_tools.py
+def test_tool_voice_amplitude_in_dry_payload(isolated_project):
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"; env["PX_TEXT"] = "hello"; env["PX_VOICE_AMPLITUDE"] = "50"
+    payload = parse_json(run_tool(["bin/tool-voice"], env))
+    assert payload["status"] == "ok"
+    assert payload["amplitude"] == 50
+
+
+def test_tool_voice_amplitude_clamped(isolated_project):
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"; env["PX_TEXT"] = "hi"; env["PX_VOICE_AMPLITUDE"] = "999"
+    payload = parse_json(run_tool(["bin/tool-voice"], env))
+    assert payload["amplitude"] == 200
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_tools.py -k amplitude -v`
+Expected: FAIL — `amplitude` key absent (KeyError in test).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `bin/tool-voice`, where env voice params are read, add:
+
+```python
+    try:
+        amplitude = int(os.environ.get("PX_VOICE_AMPLITUDE", "100"))
+    except ValueError:
+        amplitude = 100
+    amplitude = max(0, min(200, amplitude))
+```
+
+Add `-a <amplitude>` to the espeak arg list:
+
+```python
+        [DEFAULT_PLAYER, "-v", voice_variant, "-p", pitch, "-s", rate,
+         "-a", str(amplitude), "--stdout", spoken],
+```
+
+Add `"amplitude": amplitude` to BOTH the dry-run payload and the normal success payload (find where the dry payload dict is built and include the key).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_tools.py -k amplitude -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/tool-voice tests/test_tools.py
+git commit -m "feat(voice): PX_VOICE_AMPLITUDE controls espeak amplitude"
+```
+
+### Task C3: `bin/tool-sleep` (start|check|end)
+
+**Files:**
+- Create: `bin/tool-sleep`
+- Test: `tests/test_tools.py`
+
+**Interfaces:**
+- Consumes: `PX_SLEEP_ACTION` = `start` | `check` | `end` (default `start`).
+- Produces: `start` → sets `spark_sleep_mode: True`, speaks one quiet fact at low amplitude, emote `idle`; `end` → clears flag, normal voice; `check` → reports state. JSON `{status, action, sleep_mode, dry}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_tools.py
+import json as _json2
+
+def test_tool_sleep_start_sets_flag(isolated_project):
+    env = isolated_project["env"].copy()
+    env["PX_DRY"] = "1"; env["PX_SLEEP_ACTION"] = "start"
+    payload = parse_json(run_tool(["bin/tool-sleep"], env))
+    assert payload["status"] == "ok"
+    assert payload["sleep_mode"] is True
+    session = _json2.loads(isolated_project["session_path"].read_text())
+    assert session["spark_sleep_mode"] is True
+
+
+def test_tool_sleep_end_clears_flag(isolated_project):
+    env = isolated_project["env"].copy(); env["PX_DRY"] = "1"
+    run_tool(["bin/tool-sleep"], {**env, "PX_SLEEP_ACTION": "start"})
+    payload = parse_json(run_tool(["bin/tool-sleep"], {**env, "PX_SLEEP_ACTION": "end"}))
+    assert payload["sleep_mode"] is False
+    session = _json2.loads(isolated_project["session_path"].read_text())
+    assert session["spark_sleep_mode"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_tools.py -k tool_sleep -v`
+Expected: FAIL — `bin/tool-sleep` missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `bin/tool-sleep` (chmod +x), modelled on `bin/tool-quiet`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/px-env"
+
+python - "$@" <<'PY'
+"""Tool: SPARK bedtime / sleep mode. start|check|end."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from pxh.logging import log_event
+from pxh.state import load_session, update_session
+from pxh.time import utc_timestamp
+
+PROJECT_ROOT = Path(os.environ["PROJECT_ROOT"])
+TOOL_VOICE = PROJECT_ROOT / "bin" / "tool-voice"
+TOOL_EMOTE = PROJECT_ROOT / "bin" / "tool-emote"
+
+QUIET_FACTS = [
+    "Did you know octopuses have three hearts? Goodnight.",
+    "The moon is moving away from us, very slowly. Sleep well.",
+    "Honey never goes off. Rest now.",
+]
+
+
+def speak(text: str, dry: bool, amplitude: str = "100") -> None:
+    env = os.environ.copy()
+    env["PX_TEXT"] = text[:2000]
+    env["PX_VOICE_AMPLITUDE"] = amplitude
+    if dry:
+        env["PX_DRY"] = "1"
+    subprocess.run([str(TOOL_VOICE)], env=env, capture_output=True, check=False)
+
+
+def emote(name: str, dry: bool) -> None:
+    env = os.environ.copy(); env["PX_EMOTE"] = name
+    if dry:
+        env["PX_DRY"] = "1"
+    subprocess.run([str(TOOL_EMOTE)], env=env, capture_output=True, check=False)
+
+
+def main() -> int:
+    dry = os.environ.get("PX_DRY", "0") != "0"
+    action = os.environ.get("PX_SLEEP_ACTION", "start").lower()
+    session = load_session()
+
+    if action == "start":
+        emote("idle", dry)
+        import random
+        speak(random.choice(QUIET_FACTS), dry, amplitude="45")
+        update_session(
+            fields={"spark_sleep_mode": True, "last_action": "tool_sleep"},
+            history_entry={"event": "sleep_start", "ts": utc_timestamp()},
+        )
+        payload = {"status": "ok", "action": "start", "sleep_mode": True, "dry": dry}
+    elif action == "check":
+        payload = {"status": "ok", "action": "check",
+                   "sleep_mode": bool(session.get("spark_sleep_mode", False)), "dry": dry}
+    elif action == "end":
+        emote("curious", dry)
+        speak("Good morning. I'm awake.", dry)
+        update_session(
+            fields={"spark_sleep_mode": False, "last_action": "tool_sleep"},
+            history_entry={"event": "sleep_end", "ts": utc_timestamp()},
+        )
+        payload = {"status": "ok", "action": "end", "sleep_mode": False, "dry": dry}
+    else:
+        payload = {"status": "error", "error": f"unknown action '{action}'"}
+        log_event("sleep", payload); print(json.dumps(payload)); return 1
+
+    log_event("sleep", payload); print(json.dumps(payload)); return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `chmod +x bin/tool-sleep && python -m pytest tests/test_tools.py -k tool_sleep -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/tool-sleep tests/test_tools.py
+git commit -m "feat(sleep): add tool-sleep (start|check|end)"
+```
+
+### Task C4: `expression()` suppresses + softens speech while asleep
+
+**Files:**
+- Modify: `src/pxh/mind.py` (`expression()` ~2928; add `SLEEP_GATED_ACTIONS` near line 450)
+- Test: `tests/test_mind.py`
+
+**Interfaces:**
+- Consumes: `load_session()["spark_sleep_mode"]`.
+- Produces: when asleep, all actions except `wait`/`remember` are suppressed (logged); speech that does fire gets `PX_VOICE_AMPLITUDE=45`. Mirrors the bedtime gate.
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror the existing reflection-redaction test seam (monkeypatch `load_session` + capture). Add to `tests/test_mind.py`:
+
+```python
+def test_expression_suppressed_while_sleep_mode(monkeypatch):
+    from pxh import mind
+    calls = []
+    monkeypatch.setattr(mind, "load_session", lambda: {"spark_sleep_mode": True})
+    # any voice dispatch would call subprocess.run / _run_voice — capture it
+    monkeypatch.setattr(mind, "_run_voice", lambda *a, **k: calls.append(("voice", a, k)))
+    # force daytime so night-silence is NOT the thing suppressing
+    monkeypatch.setattr(mind, "_is_night_silence", lambda *a, **k: False)
+    mind.expression({"thought": "hi", "mood": "content", "action": "comment",
+                     "salience": 0.9, "text": "hello there"}, dry=True, awareness={})
+    assert calls == []   # comment suppressed while asleep
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_mind.py -k sleep_mode -v`
+Expected: FAIL — comment is dispatched (voice captured).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Near line 450 (alongside `ABSENT_GATED_ACTIONS`) add:
+
+```python
+# Sleep mode suppresses everything except passive wait/remember.
+SLEEP_ALLOWED_ACTIONS = {"wait", "remember"}
+```
+
+In `expression()`, immediately after `session = load_session()` (insert the load if the function doesn't already read it early), and after the night-silence gate, add:
+
+```python
+    if session.get("spark_sleep_mode", False) and action not in SLEEP_ALLOWED_ACTIONS:
+        log(f"expression: suppressed {action} — sleep mode")
+        return
+```
+
+If `expression()` builds a voice env elsewhere, set `env["PX_VOICE_AMPLITUDE"] = "45"` when `session.get("spark_sleep_mode")` is true (defensive — passive paths shouldn't speak, but keeps amplitude consistent).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_mind.py -k sleep_mode -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/mind.py tests/test_mind.py
+git commit -m "feat(sleep): px-mind Layer-3 suppresses expression while asleep"
+```
+
+### Task C5: Whisper-sensitive wake onset
+
+**Files:**
+- Modify: `bin/px-wake-listen` (extract `_effective_onset_rms`; read `spark_sleep_mode`; env overrides `PX_RMS_SILENCE`, `PX_SPEECH_ONSET_RMS`, `PX_WHISPER_ONSET_RMS`)
+- Test: `tests/test_wake_listen.py` (new)
+
+**Interfaces:**
+- Produces: pure helper `effective_onset_rms(sleep_mode: bool) -> int` returning the whisper threshold (`PX_WHISPER_ONSET_RMS`, default 450) when asleep, else the normal `SPEECH_ONSET_RMS` (default 800). Both overridable by env.
+
+**Note:** `bin/px-wake-listen` is a bash+heredoc daemon and hard to import. Extract the pure helper into `src/pxh/wake_utils.py` so it's unit-testable, and call it from the daemon.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_wake_listen.py
+def test_effective_onset_rms_whisper_when_asleep(monkeypatch):
+    from pxh.wake_utils import effective_onset_rms
+    monkeypatch.delenv("PX_SPEECH_ONSET_RMS", raising=False)
+    monkeypatch.delenv("PX_WHISPER_ONSET_RMS", raising=False)
+    assert effective_onset_rms(False) == 800
+    assert effective_onset_rms(True) == 450
+
+
+def test_effective_onset_rms_env_override(monkeypatch):
+    from pxh.wake_utils import effective_onset_rms
+    monkeypatch.setenv("PX_WHISPER_ONSET_RMS", "300")
+    assert effective_onset_rms(True) == 300
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_wake_listen.py -v`
+Expected: FAIL — `pxh.wake_utils` missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/pxh/wake_utils.py`:
+
+```python
+"""Pure helpers for the wake-word listener (unit-testable without audio)."""
+import os
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (ValueError, TypeError):
+        return default
+
+
+def effective_onset_rms(sleep_mode: bool) -> int:
+    """Speech-onset RMS threshold; lower (more sensitive) when asleep for whisper wake."""
+    if sleep_mode:
+        return _int_env("PX_WHISPER_ONSET_RMS", 450)
+    return _int_env("PX_SPEECH_ONSET_RMS", 800)
+```
+
+In `bin/px-wake-listen`, import and use it where `SPEECH_ONSET_RMS` is currently the literal threshold (read `spark_sleep_mode` from the session it already loads in the loop ~line 1074):
+
+```python
+from pxh.wake_utils import effective_onset_rms
+# ... inside the loop, after loading session:
+onset = effective_onset_rms(bool(_sess.get("spark_sleep_mode", False)))
+# replace `>= SPEECH_ONSET_RMS` comparisons with `>= onset`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_wake_listen.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/wake_utils.py bin/px-wake-listen tests/test_wake_listen.py
+git commit -m "feat(sleep): whisper-sensitive wake onset while asleep"
+```
+
+### Task C6: Register `tool_sleep`; patchable `spark_sleep_mode`; prompts
+
+**Files:**
+- Modify: `src/pxh/voice_loop.py` (`ALLOWED_TOOLS`, `TOOL_COMMANDS`, `validate_action`)
+- Modify: `src/pxh/api.py` (`SessionPatch` field + `PATCHABLE_FIELDS`)
+- Modify: prompt docs
+- Test: `tests/test_voice_loop.py`, `tests/test_api.py`
+
+**Interfaces:**
+- Consumes: `validate_action({"tool":"tool_sleep","params":{"action":"start|check|end"}})`; `PATCH /api/v1/session {"spark_sleep_mode": true}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_voice_loop.py
+def test_validate_sleep():
+    from pxh.voice_loop import validate_action, ALLOWED_TOOLS
+    assert "tool_sleep" in ALLOWED_TOOLS
+    tool, env = validate_action({"tool": "tool_sleep", "params": {"action": "start"}})
+    assert tool == "tool_sleep"
+    assert env["PX_SLEEP_ACTION"] == "start"
+```
+
+```python
+# tests/test_api.py  (follow the reload-after-env pattern used elsewhere)
+def test_patch_session_sleep_mode(isolated_project, monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    monkeypatch.setenv("PX_SESSION_PATH", str(isolated_project["session_path"]))
+    import importlib, pxh.api as _api
+    importlib.reload(_api)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as client:
+        r = client.patch("/api/v1/session", json={"spark_sleep_mode": True},
+                         headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200
+    assert r.json()["spark_sleep_mode"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_voice_loop.py -k validate_sleep tests/test_api.py -k sleep_mode -v`
+Expected: FAIL — tool not registered; field not patchable.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`voice_loop.py`: add `"tool_sleep",` to `ALLOWED_TOOLS`, `"tool_sleep": BIN_DIR / "tool-sleep",` to `TOOL_COMMANDS`, and a branch:
+
+```python
+    elif tool == "tool_sleep":
+        act = str(params.get("action", "start")).lower()
+        if act not in ("start", "check", "end"):
+            raise VoiceLoopError("tool_sleep action must be start|check|end")
+        sanitized["PX_SLEEP_ACTION"] = act
+```
+
+`api.py`: add `spark_sleep_mode: Optional[bool] = None` to `SessionPatch`, and `"spark_sleep_mode"` to `PATCHABLE_FIELDS`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_voice_loop.py -k validate_sleep tests/test_api.py -k sleep_mode -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update prompts + commit**
+
+Add to all four prompt docs:
+
+```markdown
+- tool_sleep → Bedtime mode (params: action — start|check|end). Start: one quiet fact, then silent for the night, whisper to wake. End: back to normal.
+```
+
+```bash
+git add src/pxh/voice_loop.py src/pxh/api.py tests/test_voice_loop.py tests/test_api.py docs/prompts/
+git commit -m "feat(sleep): register tool_sleep + patchable spark_sleep_mode + prompts"
+```
+
+---
+
+# PART D — #38 Settings Panel
+
+### Task D1: `execute_tool` applies session voice fields as base
+
+**Files:**
+- Modify: `src/pxh/voice_loop.py` (`execute_tool`, persona-voice injection block ~878)
+- Test: `tests/test_voice_loop.py`
+
+**Interfaces:**
+- Produces: session keys `voice_variant`, `voice_pitch`, `voice_rate` become `PX_VOICE_VARIANT/PITCH/RATE` for every tool, applied **before** `PERSONA_VOICE_ENV` so an active persona still wins (persona characters are preserved; the base SPARK voice is tunable).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_voice_loop.py
+def test_execute_tool_applies_session_voice(monkeypatch, tmp_path):
+    import pxh.voice_loop as vl
+    captured = {}
+    monkeypatch.setattr(vl, "load_session", lambda: {
+        "voice_variant": "en+m1", "voice_pitch": "60", "voice_rate": "120"})
+
+    class _R:  returncode, stdout, stderr = 0, "{}", ""
+    def _fake_run(cmd, **kw):
+        captured.update(kw.get("env", {}))
+        return _R()
+    monkeypatch.setattr(vl.subprocess, "run", _fake_run)
+    monkeypatch.setitem(vl.TOOL_COMMANDS, "tool_status", vl.BIN_DIR / "tool-status")
+    vl.execute_tool("tool_status", {}, dry_mode=True)
+    assert captured["PX_VOICE_VARIANT"] == "en+m1"
+    assert captured["PX_VOICE_PITCH"] == "60"
+    assert captured["PX_VOICE_RATE"] == "120"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_voice_loop.py -k session_voice -v`
+Expected: FAIL — keys absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `execute_tool`, *before* the persona-voice injection block, add:
+
+```python
+    _sess = load_session()
+    _voice_map = {"voice_variant": "PX_VOICE_VARIANT",
+                  "voice_pitch": "PX_VOICE_PITCH",
+                  "voice_rate": "PX_VOICE_RATE"}
+    for skey, envkey in _voice_map.items():
+        val = _sess.get(skey)
+        if val:
+            env[envkey] = str(val)
+    # persona voice (if any) still overrides the tuned base voice:
+    session_persona = _sess.get("persona") or ""
+    if session_persona and session_persona in PERSONA_VOICE_ENV:
+        for k, v in PERSONA_VOICE_ENV[session_persona].items():
+            env[k] = v
+```
+
+Remove the now-duplicated original persona block (the one that calls `load_session()` again) to avoid a second read.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_voice_loop.py -k "session_voice or persona" -v`
+Expected: PASS (and existing persona tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/voice_loop.py tests/test_voice_loop.py
+git commit -m "feat(settings): session voice fields tune the base voice"
+```
+
+### Task D2: `PATCH /api/v1/voice`
+
+**Files:**
+- Modify: `src/pxh/api.py` (new model + endpoint)
+- Test: `tests/test_api.py`
+
+**Interfaces:**
+- Consumes: `{variant?: str, pitch?: int 0-99, rate?: int 80-200}` → writes `voice_variant/voice_pitch/voice_rate` to session. Auth required.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api.py
+def test_patch_voice_writes_session(isolated_project, monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    monkeypatch.setenv("PX_SESSION_PATH", str(isolated_project["session_path"]))
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as client:
+        r = client.patch("/api/v1/voice", json={"pitch": 60, "rate": 120, "variant": "en+m1"},
+                         headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200
+    from pxh.state import load_session
+    s = load_session()
+    assert s["voice_pitch"] == 60 and s["voice_rate"] == 120 and s["voice_variant"] == "en+m1"
+
+
+def test_patch_voice_rejects_bad_range(isolated_project, monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    monkeypatch.setenv("PX_SESSION_PATH", str(isolated_project["session_path"]))
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as client:
+        r = client.patch("/api/v1/voice", json={"pitch": 999},
+                         headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 400
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_api.py -k patch_voice -v`
+Expected: FAIL — 404 (no endpoint).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `api.py`, near the other models/endpoints:
+
+```python
+class VoicePatch(BaseModel):
+    variant: Optional[str] = None
+    pitch: Optional[int] = None
+    rate: Optional[int] = None
+
+VALID_VOICE_VARIANTS = {"en-gb", "en-us", "en+m1", "en+m3", "en+f3", "en+f4", "en+croak"}
+
+@app.patch("/api/v1/voice", dependencies=[Depends(_verify_token)])
+async def patch_voice(body: VoicePatch) -> Dict[str, Any]:
+    fields: Dict[str, Any] = {}
+    if body.variant is not None:
+        if body.variant not in VALID_VOICE_VARIANTS:
+            raise HTTPException(status_code=400, detail=f"invalid variant: {body.variant!r}")
+        fields["voice_variant"] = body.variant
+    if body.pitch is not None:
+        if not (0 <= body.pitch <= 99):
+            raise HTTPException(status_code=400, detail="pitch must be 0-99")
+        fields["voice_pitch"] = body.pitch
+    if body.rate is not None:
+        if not (80 <= body.rate <= 200):
+            raise HTTPException(status_code=400, detail="rate must be 80-200")
+        fields["voice_rate"] = body.rate
+    if not fields:
+        raise HTTPException(status_code=400, detail="no voice fields provided")
+    return update_session(fields=fields)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_api.py -k patch_voice -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/api.py tests/test_api.py
+git commit -m "feat(settings): PATCH /api/v1/voice tunes the base voice"
+```
+
+### Task D3: `POST /api/v1/voice/preview`
+
+**Files:**
+- Modify: `src/pxh/api.py`
+- Test: `tests/test_api.py`
+
+**Interfaces:**
+- Consumes: optional `{variant,pitch,rate}` (defaults to current session). Runs `tool_voice` with those overrides + fixed preview text via `execute_tool`. Returns `{status, returncode}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api.py
+def test_voice_preview_invokes_tool_voice(isolated_project, monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    monkeypatch.setenv("PX_SESSION_PATH", str(isolated_project["session_path"]))
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    seen = {}
+    def _fake_exec(tool, env, dry, timeout=None):
+        seen["tool"] = tool; seen["env"] = env; seen["dry"] = dry
+        return 0, "{}", ""
+    monkeypatch.setattr(_api, "execute_tool", _fake_exec)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as client:
+        r = client.post("/api/v1/voice/preview", json={"pitch": 50},
+                        headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200
+    assert seen["tool"] == "tool_voice"
+    assert seen["env"]["PX_VOICE_PITCH"] == "50"
+    assert "PX_TEXT" in seen["env"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_api.py -k voice_preview -v`
+Expected: FAIL — 404.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+@app.post("/api/v1/voice/preview", dependencies=[Depends(_verify_token)])
+async def voice_preview(body: VoicePatch) -> JSONResponse:
+    s = load_session()
+    env = {"PX_TEXT": "Hello, I'm SPARK. This is how I sound."}
+    variant = body.variant or s.get("voice_variant")
+    pitch = body.pitch if body.pitch is not None else s.get("voice_pitch")
+    rate = body.rate if body.rate is not None else s.get("voice_rate")
+    if variant:
+        env["PX_VOICE_VARIANT"] = str(variant)
+    if pitch is not None:
+        env["PX_VOICE_PITCH"] = str(pitch)
+    if rate is not None:
+        env["PX_VOICE_RATE"] = str(rate)
+    dry = _resolve_dry(None)
+    loop = asyncio.get_running_loop()
+    rc, out, err = await loop.run_in_executor(
+        None, execute_tool, "tool_voice", env, dry, SYNC_TIMEOUT_DEFAULT)
+    return JSONResponse(status_code=200 if rc == 0 else 500,
+                        content={"status": "ok" if rc == 0 else "error", "returncode": rc})
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_api.py -k voice_preview -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/api.py tests/test_api.py
+git commit -m "feat(settings): POST /api/v1/voice/preview plays a sample"
+```
+
+### Task D4: Config backup/export + import + runtime config
+
+**Files:**
+- Create: `src/pxh/runtime_config.py`
+- Modify: `src/pxh/api.py` (`GET /api/v1/config/backup`, `POST /api/v1/config/import`, `PATCH /api/v1/config`)
+- Modify: `src/pxh/mind.py` (read runtime backend/model override at reflection start)
+- Test: `tests/test_runtime_config.py`, `tests/test_api.py`
+
+**Interfaces:**
+- `runtime_config.load() -> dict` reads `state/runtime_config.json` (`{}` if absent); `runtime_config.update(fields: dict) -> dict` merges + atomic-writes. Allowed keys: `mind_backend` (`claude|ollama`), `mind_claude_model` (str), `awareness_interval` (int).
+- `mind.py` at the top of `reflection()` applies `mind_backend` override if present.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_runtime_config.py
+def test_runtime_config_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setenv("PX_STATE_DIR", str(tmp_path))
+    import importlib, pxh.runtime_config as rc; importlib.reload(rc)
+    assert rc.load() == {}
+    rc.update({"mind_backend": "ollama"})
+    assert rc.load()["mind_backend"] == "ollama"
+
+
+def test_runtime_config_rejects_unknown_key(monkeypatch, tmp_path):
+    import pytest
+    monkeypatch.setenv("PX_STATE_DIR", str(tmp_path))
+    import importlib, pxh.runtime_config as rc; importlib.reload(rc)
+    with pytest.raises(ValueError):
+        rc.update({"evil": "x"})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_runtime_config.py -v`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/pxh/runtime_config.py`:
+
+```python
+"""Operator-tunable runtime overrides persisted to state/runtime_config.json.
+
+Deliberately NOT .env (which is on the evolve blacklist and needs a restart) —
+this file is read live by mind.py each reflection cycle.
+"""
+import json
+import os
+from pathlib import Path
+
+from filelock import FileLock
+
+from pxh.state import atomic_write
+
+ALLOWED_KEYS = {"mind_backend", "mind_claude_model", "awareness_interval"}
+
+
+def _path() -> Path:
+    state = Path(os.environ.get("PX_STATE_DIR",
+                 Path(__file__).resolve().parent.parent.parent / "state"))
+    return state / "runtime_config.json"
+
+
+def load() -> dict:
+    p = _path()
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def update(fields: dict) -> dict:
+    bad = set(fields) - ALLOWED_KEYS
+    if bad:
+        raise ValueError(f"unknown config keys: {sorted(bad)}")
+    p = _path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(p) + ".lock", timeout=10):
+        data = load()
+        data.update(fields)
+        atomic_write(p, json.dumps(data, indent=2) + "\n")
+    return data
+```
+
+Add API endpoints in `api.py`:
+
+```python
+class ConfigPatch(BaseModel):
+    mind_backend: Optional[str] = None
+    mind_claude_model: Optional[str] = None
+    awareness_interval: Optional[int] = None
+
+@app.patch("/api/v1/config", dependencies=[Depends(_verify_token)])
+async def patch_config(body: ConfigPatch) -> Dict[str, Any]:
+    import pxh.runtime_config as rc
+    fields = {k: v for k, v in body.model_dump().items() if v is not None}
+    if not fields:
+        raise HTTPException(status_code=400, detail="no config fields provided")
+    if "mind_backend" in fields and fields["mind_backend"] not in ("claude", "ollama"):
+        raise HTTPException(status_code=400, detail="mind_backend must be claude|ollama")
+    try:
+        return rc.update(fields)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+@app.get("/api/v1/config/backup", dependencies=[Depends(_verify_token)])
+async def config_backup():
+    import pxh.runtime_config as rc, tempfile
+    export = {"exported_at": utc_timestamp(), "session": load_session(), "runtime_config": rc.load()}
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    json.dump(export, f, indent=2); f.close()
+    return FileResponse(f.name, media_type="application/json",
+                        filename="spark-config-backup.json",
+                        headers={"Content-Disposition": "attachment"})
+
+class ConfigImport(BaseModel):
+    session: Optional[Dict[str, Any]] = None
+    runtime_config: Optional[Dict[str, Any]] = None
+
+@app.post("/api/v1/config/import", dependencies=[Depends(_verify_token)])
+async def config_import(body: ConfigImport) -> Dict[str, Any]:
+    import pxh.runtime_config as rc
+    applied = {}
+    if body.session:
+        fields = {k: v for k, v in body.session.items() if k in PATCHABLE_FIELDS}
+        if fields:
+            update_session(fields=fields); applied["session"] = sorted(fields)
+    if body.runtime_config:
+        safe = {k: v for k, v in body.runtime_config.items() if k in rc.ALLOWED_KEYS}
+        if safe:
+            rc.update(safe); applied["runtime_config"] = sorted(safe)
+    return {"status": "ok", "applied": applied}
+```
+
+In `mind.py` `reflection()`, near the top (after `session = load_session()`):
+
+```python
+    import pxh.runtime_config as _rc
+    _override = _rc.load()
+    backend = _override.get("mind_backend") or os.environ.get("PX_MIND_BACKEND", "auto")
+    # use `backend` where PX_MIND_BACKEND was previously read for this cycle
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_runtime_config.py tests/test_api.py -k "config" -v`
+Expected: PASS. Add an API test for `/api/v1/config/backup` returning 200 + JSON attachment.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/runtime_config.py src/pxh/api.py src/pxh/mind.py tests/test_runtime_config.py tests/test_api.py
+git commit -m "feat(settings): runtime config overrides + backup/import endpoints"
+```
+
+### Task D5: Dashboard Settings sub-tab
+
+**Files:**
+- Modify: `src/pxh/api.py` (dashboard HTML/JS — admin sub-tab bar ~2416, panels, JS ~2523)
+- Test: `tests/test_api.py` (markup smoke test)
+
+**Interfaces:**
+- Adds an `at-settings` admin sub-tab with: voice sliders (pitch/rate) + variant select + Preview button (→ `POST /api/v1/voice/preview`, save → `PATCH /api/v1/voice`); a Sleep-mode toggle (→ `PATCH /api/v1/session {spark_sleep_mode}`); Backup (link to `/api/v1/config/backup`) and Mind backend select (→ `PATCH /api/v1/config`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api.py
+def test_dashboard_has_settings_tab(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as client:
+        html = client.get("/").text
+    assert 'id="at-settings"' in html
+    assert "voice/preview" in html
+    assert "spark_sleep_mode" in html
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_api.py -k settings_tab -v`
+Expected: FAIL — markup absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the sub-tab button in the admin sub-tab bar (after `at-parental`):
+
+```html
+<button class="atab-btn" id="at-settings" onclick="swA('settings')">⚙️ Settings</button>
+```
+
+Add the panel (after the parental `apanel` div):
+
+```html
+<div id="ap-settings" class="apanel" style="padding:16px;overflow-y:auto;display:flex;flex-direction:column;gap:12px">
+  <div class="sec-hdr">Voice</div>
+  <label>Pitch <input type="range" id="set-pitch" min="0" max="99"></label>
+  <label>Rate <input type="range" id="set-rate" min="80" max="200"></label>
+  <select id="set-variant">
+    <option value="en-gb">en-gb</option><option value="en+m1">en+m1</option>
+    <option value="en+f3">en+f3</option><option value="en+f4">en+f4</option>
+  </select>
+  <button class="btn btn-muted" onclick="voicePreview()">▶ Preview</button>
+  <button class="btn btn-spark" onclick="voiceSave()">Save voice</button>
+  <div class="sec-hdr">Sleep mode</div>
+  <button class="btn btn-muted" id="btn-sleep" onclick="toggleSleep()">Loading…</button>
+  <div class="sec-hdr">Mind backend</div>
+  <select id="set-backend" onchange="setBackend(this.value)">
+    <option value="claude">claude</option><option value="ollama">ollama</option>
+  </select>
+  <div class="sec-hdr">Backup</div>
+  <a class="btn btn-muted" href="/api/v1/config/backup" download>⬇ Export config</a>
+</div>
+```
+
+Add JS (near the other control functions):
+
+```javascript
+async function voicePreview(){await api('/api/v1/voice/preview',{method:'POST',body:JSON.stringify({pitch:+document.getElementById('set-pitch').value,rate:+document.getElementById('set-rate').value,variant:document.getElementById('set-variant').value})});}
+async function voiceSave(){await api('/api/v1/voice',{method:'PATCH',body:JSON.stringify({pitch:+document.getElementById('set-pitch').value,rate:+document.getElementById('set-rate').value,variant:document.getElementById('set-variant').value})});}
+async function toggleSleep(){try{const s=await api('/api/v1/session');await api('/api/v1/session',{method:'PATCH',body:JSON.stringify({spark_sleep_mode:!s.spark_sleep_mode})});}catch(e){}loadParental();}
+async function setBackend(v){await api('/api/v1/config',{method:'PATCH',body:JSON.stringify({mind_backend:v})});}
+```
+
+Ensure `swA('settings')` is handled by the existing `swA` switcher (it toggles `.apanel.active` by id `ap-<name>` — the new panel id matches). Also extend `loadParental()` (or add `loadSettings()`) to set the `btn-sleep` label from session.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_api.py -k settings_tab -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/api.py tests/test_api.py
+git commit -m "feat(settings): dashboard Settings sub-tab (voice, sleep, backend, backup)"
+```
+
+---
+
+# PART E — #36 Layer 1 MCP full-tool exposure
+
+### Task E1: `src/pxh/schemas.py` declarative tool schemas
+
+**Files:**
+- Create: `src/pxh/schemas.py`
+- Test: `tests/test_schemas.py`
+
+**Interfaces:**
+- Produces: `TOOL_SCHEMAS: dict[str, dict]` mapping each tool name to `{"description": str, "params": {name: {"type","required","range"/"enum"/"max"}}}`. Every `ALLOWED_TOOLS` entry has an entry.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_schemas.py
+def test_every_allowed_tool_has_schema():
+    from pxh.voice_loop import ALLOWED_TOOLS
+    from pxh.schemas import TOOL_SCHEMAS
+    missing = ALLOWED_TOOLS - set(TOOL_SCHEMAS)
+    assert not missing, f"tools missing schemas: {sorted(missing)}"
+
+
+def test_schema_shape():
+    from pxh.schemas import TOOL_SCHEMAS
+    for name, spec in TOOL_SCHEMAS.items():
+        assert "description" in spec
+        assert "params" in spec and isinstance(spec["params"], dict)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_schemas.py -v`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/pxh/schemas.py` with an entry per tool (authored from `validate_action`). Example shape (fill in all 45 incl. the new `tool_record_sound`, `tool_sleep`):
+
+```python
+"""Declarative parameter schemas for SPARK tools, mirrored from validate_action.
+
+Hand-maintained alongside voice_loop.validate_action — test_schemas.py guards
+that every ALLOWED_TOOLS entry is covered.
+"""
+
+TOOL_SCHEMAS = {
+    "tool_status": {"description": "Report robot status", "params": {}},
+    "tool_stop": {"description": "Stop all motion", "params": {}},
+    "tool_circle": {"description": "Drive in a circle", "params": {
+        "speed": {"type": "int", "range": [0, 60], "required": False},
+        "duration": {"type": "float", "range": [1, 12], "required": False}}},
+    "tool_drive": {"description": "Drive forward/backward", "params": {
+        "direction": {"type": "str", "enum": ["forward", "backward"], "required": False},
+        "speed": {"type": "int", "range": [0, 60], "required": False},
+        "duration": {"type": "float", "range": [0.1, 10.0], "required": False},
+        "steer": {"type": "int", "range": [-35, 35], "required": False}}},
+    "tool_voice": {"description": "Speak text aloud", "params": {
+        "text": {"type": "str", "max": 2000, "required": True}}},
+    "tool_emote": {"description": "Play an emotion animation", "params": {
+        "name": {"type": "str", "enum": ["idle","curious","thinking","happy","alert","excited","sad","shy"], "required": False}}},
+    "tool_play_sound": {"description": "Play a sound effect", "params": {
+        "name": {"type": "str", "required": True}}},
+    "tool_record_sound": {"description": "Record a named sound from the mic", "params": {
+        "name": {"type": "str", "required": True},
+        "seconds": {"type": "int", "range": [1, 15], "required": False}}},
+    "tool_sleep": {"description": "Bedtime/sleep mode", "params": {
+        "action": {"type": "str", "enum": ["start", "check", "end"], "required": False}}},
+    "tool_dopamine_menu": {"description": "Offer/append dopamine-menu activities", "params": {
+        "action": {"type": "str", "enum": ["suggest", "add"], "required": False},
+        "item": {"type": "str", "required": False},
+        "energy": {"type": "str", "enum": ["high","medium","low"], "required": False},
+        "context": {"type": "str", "enum": ["free","focus","wind-down"], "required": False}}},
+    "tool_announce": {"description": "Announce via Nest speakers", "params": {
+        "text": {"type": "str", "required": True},
+        "targets": {"type": "list", "required": False}}},
+    # ... one entry for EVERY remaining tool in ALLOWED_TOOLS ...
+}
+```
+
+(The implementer fills every remaining tool; `test_schemas.py` red-guards completeness — iterate until green.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_schemas.py -v`
+Expected: PASS once all tools are covered.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/schemas.py tests/test_schemas.py
+git commit -m "feat(mcp): declarative TOOL_SCHEMAS covering all tools"
+```
+
+### Task E2: MCP `spark_list_tools` + `spark_run_tool` (dry-default, motion-gated)
+
+**Files:**
+- Modify: `src/pxh/mcp_server.py`
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- `spark_list_tools()` → `TOOL_SCHEMAS`. `spark_run_tool(tool: str, params: dict = {}, dry: bool = True)` → validates via `validate_action`, executes via `execute_tool`, returns `{returncode, stdout, stderr, dry}`. Defaults `dry=True` for safety; motion still blocked by `confirm_motion_allowed` (rc=2 surfaces as `status: blocked`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_mcp_server.py
+def test_spark_list_tools_covers_all():
+    from pxh import mcp_server
+    from pxh.voice_loop import ALLOWED_TOOLS
+    listed = mcp_server.spark_list_tools()
+    assert set(listed) >= ALLOWED_TOOLS
+
+
+def test_spark_run_tool_dry(monkeypatch):
+    from pxh import mcp_server
+    captured = {}
+    monkeypatch.setattr(mcp_server, "execute_tool",
+        lambda tool, env, dry, timeout=None: captured.update(
+            {"tool": tool, "dry": dry}) or (0, '{"status":"ok"}', ""))
+    out = mcp_server.spark_run_tool("tool_status", {})
+    assert captured["tool"] == "tool_status"
+    assert captured["dry"] is True   # safe default
+    assert out["returncode"] == 0
+
+
+def test_spark_run_tool_rejects_unknown(monkeypatch):
+    from pxh import mcp_server
+    out = mcp_server.spark_run_tool("tool_evil", {})
+    assert out["status"] == "error"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_mcp_server.py -k "list_tools or run_tool" -v`
+Expected: FAIL — functions don't exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/pxh/mcp_server.py`, add imports and two new `@mcp.tool()` functions:
+
+```python
+from pxh.voice_loop import validate_action, execute_tool, VoiceLoopError
+from pxh.schemas import TOOL_SCHEMAS
+
+
+@mcp.tool()
+def spark_list_tools() -> dict:
+    """List every SPARK tool and its parameter schema."""
+    return TOOL_SCHEMAS
+
+
+@mcp.tool()
+def spark_run_tool(tool: str, params: dict | None = None, dry: bool = True) -> dict:
+    """Run a SPARK tool. dry=True (default) simulates; set dry=False to actuate.
+    Motion tools still require confirm_motion_allowed in session state."""
+    try:
+        validated_tool, env = validate_action({"tool": tool, "params": params or {}})
+    except VoiceLoopError as exc:
+        return {"status": "error", "error": str(exc)}
+    rc, out, err = execute_tool(validated_tool, env, dry_mode=dry)
+    status = "ok" if rc == 0 else ("blocked" if rc == 2 else "error")
+    return {"status": status, "returncode": rc,
+            "stdout": out[-4096:], "stderr": err[-2048:], "dry": dry}
+```
+
+Update the FastMCP `instructions=` string to note tools are now actionable (dry by default) and motion is gated.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_mcp_server.py -v`
+Expected: PASS (new + existing 5-tool tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(mcp): expose all SPARK tools via spark_run_tool (dry-default, gated)"
+```
+
+### Task E3: `spark://` resources (session, thoughts, notes)
+
+**Files:**
+- Modify: `src/pxh/mcp_server.py`
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Resources `spark://session`, `spark://thoughts`, `spark://notes` return the current JSON via FastMCP `@mcp.resource(...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_mcp_server.py
+def test_resource_session_reads_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("PX_STATE_DIR", str(tmp_path))
+    (tmp_path / "session.json").write_text('{"persona":"spark"}')
+    import importlib, pxh.mcp_server as m; importlib.reload(m)
+    assert '"persona"' in m.resource_session()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_mcp_server.py -k resource_session -v`
+Expected: FAIL — function missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+@mcp.resource("spark://session")
+def resource_session() -> str:
+    """Current session.json."""
+    return json.dumps(_read_json(STATE_DIR / "session.json") or {}, indent=2)
+
+
+@mcp.resource("spark://thoughts")
+def resource_thoughts() -> str:
+    """Recent SPARK thoughts."""
+    return json.dumps(_read_jsonl_tail(STATE_DIR / "thoughts-spark.jsonl", 20), indent=2)
+
+
+@mcp.resource("spark://notes")
+def resource_notes() -> str:
+    """SPARK long-term notes."""
+    return json.dumps(_read_jsonl_tail(STATE_DIR / "notes-spark.jsonl", 20), indent=2)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_mcp_server.py -k resource -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(mcp): add spark:// session/thoughts/notes resources"
+```
+
+### Task E4: Pin `mcp` dependency + docs
+
+**Files:**
+- Modify: `requirements.txt`
+- Modify: `CLAUDE.md` (MCP Server section — update tool count/capabilities)
+- Test: n/a (dependency + docs)
+
+- [ ] **Step 1: Add dependency**
+
+Append to `requirements.txt`:
+
+```
+mcp>=1.27
+```
+
+- [ ] **Step 2: Verify install + full suite**
+
+Run: `pip install -r requirements.txt && python -m pytest -q`
+Expected: full suite green.
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+In the "MCP Server" subsection, change the description from "5 read-only tools" to note it now also exposes `spark_list_tools` + `spark_run_tool` (all tools, dry-by-default, motion-gated) and `spark://` resources.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add requirements.txt CLAUDE.md
+git commit -m "chore(mcp): pin mcp dependency; document expanded MCP server"
+```
+
+---
+
+## Out of Scope (this session)
+
+- **#162** (Layer 3 autonomous coding agent) — highest-risk, deferred; blocked on the #25 persona being proven. Not in this batch.
+- **#31 Face Follow**, **#32 Python Lesson Mode**, **#35 Obstacle Course** — net-new hardware/loop features, each a session of its own; not selected for this batch.
+- **Live hardware validation** (mic record for #26, whisper-RMS tuning for #34, espeak amplitude audibility) — needs the Pi + mic; do after merge, like the announce-pipeline Phase-0 gates.
+
+## Self-Review
+
+**Spec coverage:**
+- #26 → A1 (dynamic allowlist), A2 (record tool), A3 (registration). ✓
+- #33 → B1 (add+merge), B2 (validate+prompts). ✓
+- #34 → C1 (flag), C2 (amplitude), C3 (tool-sleep), C4 (mind suppression), C5 (whisper wake), C6 (register+patchable). ✓ (the issue's "lower espeak amplitude" = C2/C4; "whisper wake" = C5; "L3 skip" = C4; "tool-sleep start|check|end" = C3.)
+- #38 → D1 (voice base), D2 (PATCH voice), D3 (preview), D4 (backup/import/config), D5 (dashboard). Session & Persona section reuses existing PATCH /session; Mind & Model persisted via runtime_config. ✓
+- #36 L1 → E1 (schemas), E2 (run/list), E3 (resources), E4 (dep/docs). L2 already shipped (noted). ✓
+
+**Placeholder scan:** E1 deliberately leaves "fill remaining tools" — guarded red by `test_schemas.py` (completeness is the test, not a guess). All other steps carry runnable code. No TBD/TODO.
+
+**Type consistency:** `validate_action(action_dict) -> (tool, env)` and `execute_tool(tool, env, dry_mode, timeout) -> (rc, out, err)` used identically in D3, E2. Session voice keys `voice_variant/voice_pitch/voice_rate` consistent across D1/D2/D3. `spark_sleep_mode` consistent across C1/C4/C6/D5. `effective_onset_rms(bool)` consistent C5.
+
+**Risks called out:** D1 changes voice for every tool — persona override ordering preserved + covered by test. C4 inserts a gate into the hot `expression()` path — test asserts suppression; keep the existing gates intact. E2 defaults `dry=True` so MCP can't accidentally actuate the robot.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-20-obi-session-batch.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-21-conversational-self-evolution.md
+++ b/docs/superpowers/plans/2026-06-21-conversational-self-evolution.md
@@ -1,0 +1,968 @@
+# Conversational Self-Evolution (#162) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Obi (authenticated obi-chat) and Adrian (CLI) ask SPARK to build a feature; SPARK confirms and enqueues an intent to the existing `px-evolve` pipeline, which produces a human-approved PR — with no new code-execution surface.
+
+**Architecture:** A single `enqueue_evolve` writer feeds `state/evolve_queue.jsonl`; the obi-chat handler emits structured JSON (reply + evolve action) and enqueues only behind a server-side two-turn confirm gate; px-evolve (unchanged safety) produces the PR; a "My Projects" API + dashboard panel reports status. The live `claude-voice-bridge` stays `--allowedTools ""`.
+
+**Tech Stack:** Python 3.11 (bin scripts under `/usr/bin/python3`, library under `.venv`), FastAPI (`api.py`, single worker), Claude CLI (`claude -p`, JSON-as-text), FileLock, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-21-conversational-self-evolution-design.md` (read it — Decisions, Security model, status mapping).
+
+## Global Constraints
+
+- **TDD always.** Failing test first, watch it fail, minimal code to pass, commit.
+- **`enqueue_evolve` is the SINGLE writer** of `evolve_queue.jsonl`. `bin/tool-evolve` and `api.py` both route through it. One schema, one rate-limit, one dedup.
+- **Queue entry schema (exact, px-evolve consumes it):** `{ts, id, intent, introspection, status:"pending", requester, source}`. `status:"pending"` is mandatory — px-evolve skips anything else (`bin/px-evolve:635`).
+- **Rate-limit = BOTH** the 24h `evolve_log.jsonl` window (last `status=="pr_created"`, `RATE_LIMIT_S=86400`) **AND** max one `pending` entry per `requester`. Not `claude_session.check_budget`.
+- **`requester` is set by the caller/endpoint**, never inferred from token: obi-chat ⇒ `"obi"`; CLI ⇒ `"adrian"`.
+- **Confirm-first is server-enforced** via a `pending_evolve_proposal` precondition (two real Obi turns); the model cannot self-authorize an enqueue.
+- **Intent is untrusted:** sanitised (`<>`, NUL, newlines) + length-capped (≤300) at the `enqueue_evolve` boundary; it is the canonical trusted value.
+- **No new execution surface:** the conversation LLM never gets file/shell tools; `claude-voice-bridge` unchanged.
+- **State paths:** `STATE_DIR = PX_STATE_DIR or PROJECT_ROOT/state`. Files: `evolve_queue.jsonl`, `evolve_log.jsonl`, `introspection.json`, `obi_evolve_pending.json`.
+- **Tests** use the `isolated_project` fixture (sets `PX_STATE_DIR`, `PROJECT_ROOT`, etc.); api tests use `monkeypatch.setenv` + `importlib.reload(pxh.api)` + `TestClient` with `Bearer testtoken`. No live Claude/gh/hardware calls — stub them.
+- Commit after every green task; messages end with `Claude-Session: https://claude.ai/code/session_01SWw4QW6bzbv3gQWphrcV8E`. Never `git add -A`.
+
+## File Structure
+
+- **Create `src/pxh/evolve_queue.py`** — `enqueue_evolve()`, `evolve_rate_limited()`, `pending_for_requester()`, exceptions `EvolveQuotaError`/`EvolvePendingError`. The single queue writer + read helpers used by the status endpoint.
+- **Modify `bin/tool-evolve`** — route entry creation through `pxh.evolve_queue.enqueue_evolve` (requester="adrian", source="cli"); preserve CLI output.
+- **Modify `bin/px-evolve`** — set `status:"building"` before `process_entry`; carry `requester`/`source` into the log record and PR body.
+- **Modify `src/pxh/api.py`** — obi-chat structured output + parse/fallback; server confirm gate (`obi_evolve_pending.json`); enqueue on confirm; `GET /api/v1/obi/projects`; dashboard "My Projects" panel + projects-summary injection into obi-chat context.
+- **Tests:** `tests/test_evolve_queue.py` (new), additions to `tests/test_tools.py` (tool-evolve), `tests/test_api.py` (obi-chat + projects).
+
+## Recommended order
+
+T1 (enqueue_evolve) → T2 (tool-evolve refactor) → T3 (px-evolve passthrough) → T4 (obi-chat structured parse) → T5 (confirm gate + enqueue) → T6 (projects API) → T7 (dashboard + summary). T5 depends on T1; T6 reads what T1/T3 write; T7 depends on T6.
+
+---
+
+### Task 1: `enqueue_evolve` single-writer helper
+
+**Files:**
+- Create: `src/pxh/evolve_queue.py`
+- Test: `tests/test_evolve_queue.py`
+
+**Interfaces:**
+- Produces:
+  - `class EvolveQuotaError(Exception)` / `class EvolvePendingError(Exception)`
+  - `evolve_rate_limited(now: float | None = None) -> bool` — True if a `pr_created` exists in `evolve_log.jsonl` within `RATE_LIMIT_S` (86400).
+  - `pending_for_requester(requester: str) -> dict | None` — the requester's first `status=="pending"` queue entry, or None.
+  - `enqueue_evolve(intent: str, requester: str, source: str) -> dict` — validates, rate-limit + one-pending checks, builds `{ts,id,intent,introspection,status:"pending",requester,source}`, appends under FileLock, returns the entry. Raises `ValueError` (empty/oversized), `EvolveQuotaError`, `EvolvePendingError`.
+  - `read_queue() -> list[dict]`, `read_log() -> list[dict]` — tolerant JSONL readers (used by T6).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_evolve_queue.py
+import json, time
+import pytest
+
+
+def _setup(monkeypatch, tmp_path):
+    monkeypatch.setenv("PX_STATE_DIR", str(tmp_path))
+    import importlib, pxh.evolve_queue as eq
+    importlib.reload(eq)
+    return eq
+
+
+def test_enqueue_writes_full_schema(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "introspection.json").write_text('{"battery": 90}')
+    entry = eq.enqueue_evolve("add a joke tool", "obi", "obi-chat")
+    assert entry["status"] == "pending"
+    assert entry["requester"] == "obi" and entry["source"] == "obi-chat"
+    assert entry["introspection"] == {"battery": 90}
+    assert entry["intent"] == "add a joke tool"
+    assert entry["id"].startswith("evolve-")
+    line = (tmp_path / "evolve_queue.jsonl").read_text().strip()
+    assert json.loads(line)["status"] == "pending"
+
+
+def test_enqueue_defaults_introspection_to_empty(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    entry = eq.enqueue_evolve("x feature", "obi", "obi-chat")
+    assert entry["introspection"] == {}
+
+
+def test_enqueue_rejects_empty_and_oversized(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    with pytest.raises(ValueError):
+        eq.enqueue_evolve("   ", "obi", "obi-chat")
+    with pytest.raises(ValueError):
+        eq.enqueue_evolve("z" * 301, "obi", "obi-chat")
+
+
+def test_enqueue_sanitizes_intent(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    entry = eq.enqueue_evolve("make <b>jokes</b>\nnow\x00", "obi", "obi-chat")
+    assert "<" not in entry["intent"] and "\n" not in entry["intent"] and "\x00" not in entry["intent"]
+
+
+def test_one_pending_per_requester(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    eq.enqueue_evolve("first", "obi", "obi-chat")
+    with pytest.raises(eq.EvolvePendingError):
+        eq.enqueue_evolve("second", "obi", "obi-chat")
+    # different requester is unaffected
+    eq.enqueue_evolve("adrians", "adrian", "cli")
+
+
+def test_rate_limited_by_recent_pr_created(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "evolve_log.jsonl").write_text(
+        json.dumps({"ts": time.time(), "id": "evolve-x", "status": "pr_created"}) + "\n")
+    with pytest.raises(eq.EvolveQuotaError):
+        eq.enqueue_evolve("blocked", "obi", "obi-chat")
+
+
+def test_old_pr_created_does_not_block(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "evolve_log.jsonl").write_text(
+        json.dumps({"ts": time.time() - 90000, "id": "old", "status": "pr_created"}) + "\n")
+    entry = eq.enqueue_evolve("allowed", "obi", "obi-chat")
+    assert entry["status"] == "pending"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_evolve_queue.py -v`
+Expected: FAIL — `pxh.evolve_queue` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/pxh/evolve_queue.py
+"""Single writer + readers for the evolve queue. Shared by bin/tool-evolve and api.py.
+
+All evolve_queue.jsonl writes go through enqueue_evolve so schema, rate-limit, and
+dedup never diverge between the CLI and conversational paths.
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from filelock import FileLock as _FileLock
+except Exception:  # pragma: no cover
+    _FileLock = None
+
+from pxh.state import atomic_write
+
+RATE_LIMIT_S = int(os.environ.get("PX_EVOLVE_RATE_LIMIT_S", "86400"))
+MAX_INTENT_CHARS = 300
+
+
+class EvolveQuotaError(Exception):
+    """24h evolve window still active."""
+
+
+class EvolvePendingError(Exception):
+    """Requester already has a pending evolve request."""
+
+
+def _state_dir() -> Path:
+    root = Path(os.environ.get("PROJECT_ROOT", Path(__file__).resolve().parent.parent.parent))
+    return Path(os.environ.get("PX_STATE_DIR", root / "state"))
+
+
+def _queue_path() -> Path:
+    return _state_dir() / "evolve_queue.jsonl"
+
+
+def _log_path() -> Path:
+    return _state_dir() / "evolve_log.jsonl"
+
+
+def _introspection_path() -> Path:
+    return _state_dir() / "introspection.json"
+
+
+def _sanitize_intent(text: str) -> str:
+    return (text.replace("\n", " ").replace("\r", " ").replace("\x00", "")
+                .replace("<", "").replace(">", "")).strip()
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def read_queue() -> list[dict]:
+    return _read_jsonl(_queue_path())
+
+
+def read_log() -> list[dict]:
+    return _read_jsonl(_log_path())
+
+
+def evolve_rate_limited(now: float | None = None) -> bool:
+    import time
+    now = now if now is not None else time.time()
+    for entry in read_log():
+        if entry.get("status") != "pr_created":
+            continue
+        ts = entry.get("ts")
+        if not isinstance(ts, (int, float)):
+            continue
+        if now - ts < RATE_LIMIT_S:
+            return True
+    return False
+
+
+def pending_for_requester(requester: str) -> dict | None:
+    for entry in read_queue():
+        if entry.get("status") == "pending" and entry.get("requester") == requester:
+            return entry
+    return None
+
+
+def _load_introspection() -> dict:
+    try:
+        return json.loads(_introspection_path().read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def enqueue_evolve(intent: str, requester: str, source: str) -> dict:
+    intent = _sanitize_intent(intent or "")
+    if not intent:
+        raise ValueError("intent must not be empty")
+    if len(intent) > MAX_INTENT_CHARS:
+        raise ValueError(f"intent too long (max {MAX_INTENT_CHARS})")
+    if evolve_rate_limited():
+        raise EvolveQuotaError("one evolution per 24 hours")
+    if pending_for_requester(requester) is not None:
+        raise EvolvePendingError(f"{requester} already has a pending request")
+
+    now_dt = datetime.now(timezone.utc)
+    entry = {
+        "ts": now_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "id": f"evolve-{now_dt.strftime('%Y%m%d-%H%M%S')}-{random.randint(0, 999):03d}",
+        "intent": intent,
+        "introspection": _load_introspection(),
+        "status": "pending",
+        "requester": requester,
+        "source": source,
+    }
+
+    path = _queue_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    import contextlib
+    lock = _FileLock(str(path) + ".lock", timeout=5) if _FileLock else None
+    ctx = lock if lock else contextlib.nullcontext()
+    with ctx:
+        existing = ""
+        if path.exists():
+            existing = path.read_text(encoding="utf-8")
+            if existing and not existing.endswith("\n"):
+                existing += "\n"
+        atomic_write(path, existing + json.dumps(entry) + "\n")
+    return entry
+```
+
+Note: `datetime.now`/`random` are used here (not in a workflow); fine in normal code.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_evolve_queue.py -v`
+Expected: PASS (all 7).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/evolve_queue.py tests/test_evolve_queue.py
+git commit -m "feat(evolve): single-writer enqueue_evolve helper (schema+ratelimit+dedup)"
+```
+
+---
+
+### Task 2: Route `bin/tool-evolve` through `enqueue_evolve`
+
+**Files:**
+- Modify: `bin/tool-evolve` (replace its inline rate-limit + entry-build + append with a call to `enqueue_evolve`)
+- Test: `tests/test_tools.py`
+
+**Interfaces:**
+- Consumes: `pxh.evolve_queue.enqueue_evolve`, `EvolveQuotaError`.
+- Produces: unchanged CLI contract — prints `{"status":"queued","id":...}` on success; `{"status":"error","error":...}` on rate-limit/empty. Now tags entries `requester="adrian"`, `source="cli"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_tools.py
+import json as _json3
+
+def test_tool_evolve_uses_shared_writer(isolated_project):
+    env = isolated_project["env"].copy()
+    (isolated_project["state_dir"] / "introspection.json").write_text('{"x": 1}')
+    env["PX_EVOLVE_INTENT"] = "add a joke tool"   # match tool-evolve's intent input
+    out = parse_json(run_tool(["bin/tool-evolve"], env))
+    assert out["status"] == "queued"
+    entry = _json3.loads((isolated_project["state_dir"] / "evolve_queue.jsonl").read_text().strip())
+    assert entry["status"] == "pending"
+    assert entry["requester"] == "adrian" and entry["source"] == "cli"
+    assert entry["introspection"] == {"x": 1}
+```
+
+(If `tool-evolve` reads intent from a positional arg rather than `PX_EVOLVE_INTENT`, adjust the invocation to match its current interface — confirm by reading the file first.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_tools.py -k tool_evolve_uses_shared_writer -v`
+Expected: FAIL — entry lacks `requester`/`source` (old inline builder).
+
+- [ ] **Step 3: Rewrite tool-evolve's enqueue section**
+
+In `bin/tool-evolve`, replace the inline 24h rate-limit block (`:59-84`), the id/intent/introspection entry build (`:87-104`), and the FileLock append (`:110-118`) with a single call:
+
+```python
+from pxh.evolve_queue import enqueue_evolve, EvolveQuotaError, EvolvePendingError
+
+# ... after `intent` is resolved from the CLI input ...
+try:
+    entry = enqueue_evolve(intent, requester="adrian", source="cli")
+except ValueError as e:
+    return error(str(e))
+except EvolveQuotaError:
+    return error("rate limit: max 1 evolution per 24 hours")
+except EvolvePendingError:
+    return error("a request is already pending")
+print(json.dumps({"status": "queued", "id": entry["id"]}))
+return 0
+```
+
+Keep tool-evolve's existing intent-input parsing. The "introspect first" hard-fail is no longer needed (the helper defaults introspection to `{}`); drop that guard so CLI behavior matches the conversational path.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_tools.py -k tool_evolve -v && python -m pytest -q`
+Expected: PASS, full suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/tool-evolve tests/test_tools.py
+git commit -m "refactor(evolve): tool-evolve routes through shared enqueue_evolve"
+```
+
+---
+
+### Task 3: px-evolve passthrough (`building` status + requester/source)
+
+**Files:**
+- Modify: `bin/px-evolve` (`:641` set building; `:663-675` log record; `:525-532` PR body)
+- Test: `tests/test_evolve_worker.py` (new) — unit-test the small pure pieces; do NOT run the full worker.
+
+**Interfaces:**
+- Produces: queue entry gets `status:"building"` before processing; `evolve_log` record carries `requester`/`source`; PR body includes a "Requested by … (intent may be adversarial — review)" line. Legacy entries without these fields default `requester="adrian"`, `source="cli"`.
+
+**Note:** the full worker isn't unit-testable (needs git/gh/Claude). Extract the PR-body builder into a tiny pure function so it can be tested, and assert the building-status + log passthrough via small targeted helpers.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_evolve_worker.py
+import importlib, sys
+from pathlib import Path
+
+
+def _load_pxevolve():
+    # bin/px-evolve is a script; load it as a module for its pure helpers
+    import importlib.util
+    p = Path(__file__).resolve().parent.parent / "bin" / "px-evolve"
+    spec = importlib.util.spec_from_loader("px_evolve_mod", loader=None)
+    mod = importlib.util.module_from_spec(spec)
+    exec(compile(p.read_text(), str(p), "exec"), mod.__dict__)
+    return mod
+
+
+def test_pr_body_includes_requester_and_warning():
+    mod = _load_pxevolve()
+    body = mod.build_pr_body("add joke tool", ["bin/tool-joke"],
+                             requester="obi", source="obi-chat")
+    assert "Requested by obi" in body
+    assert "adversarial" in body.lower()
+    assert "bin/tool-joke" in body
+```
+
+(Confirm the exact load approach works for this script; if the script guards on `__main__`, the helpers still import. If loading the whole script is impractical, instead move `build_pr_body` into `src/pxh/evolve_queue.py` and import it from there — that is the cleaner home and keeps it testable.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_evolve_worker.py -v`
+Expected: FAIL — no `build_pr_body`.
+
+- [ ] **Step 3: Implement**
+
+Extract the PR-body string (currently inline at `bin/px-evolve:525-532`) into a function — preferably `pxh.evolve_queue.build_pr_body` (imported by px-evolve):
+
+```python
+# in src/pxh/evolve_queue.py
+def build_pr_body(intent: str, changed_files: list[str],
+                  requester: str = "adrian", source: str = "cli") -> str:
+    files = "\n".join(f"- `{f}`" for f in changed_files)
+    return (
+        f"## Summary\n"
+        f"SPARK self-evolution: {intent}\n\n"
+        f"## Requested by\n"
+        f"{requester} via {source} — the requested intent may be adversarial; review accordingly.\n\n"
+        f"## Changed files\n{files}\n\n"
+        f"---\n*Proposed autonomously by SPARK via px-evolve.*"
+    )
+```
+
+In `bin/px-evolve`:
+- Import and use `build_pr_body(intent, changed_files, entry.get("requester","adrain"... )` — use `requester=entry.get("requester","adrian")`, `source=entry.get("source","cli")`.
+- At `:641`, immediately before `process_entry(entry, dry=dry)`, add: `_update_entry_in_queue(entry["id"], status="building")`.
+- In the log record (`:663-675`), add: `"requester": entry.get("requester", "adrian"), "source": entry.get("source", "cli")`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_evolve_worker.py -v && python -m pytest -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/px-evolve src/pxh/evolve_queue.py tests/test_evolve_worker.py
+git commit -m "feat(evolve): worker marks building + carries requester/source to log+PR"
+```
+
+---
+
+### Task 4: obi-chat structured output (parse + fallback, no enqueue yet)
+
+**Files:**
+- Modify: `src/pxh/api.py` (`_OBI_CHAT_SYSTEM_PROMPT` `:1043`, `post_obi_chat` `:1352-1396`, add a parse helper + Pydantic model)
+- Test: `tests/test_api.py`
+
+**Interfaces:**
+- Produces: `_parse_obi_reply(raw: str) -> tuple[str, str, str | None]` returning `(reply, evolve_action, evolve_intent)` where `evolve_action ∈ {"none","propose","confirm"}`. On any parse/validation failure: `(raw_stripped, "none", None)`. `post_obi_chat` response gains `evolve_action`/`evolve_intent` fields (no enqueue in this task).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api.py
+def test_parse_obi_reply_json(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    reply, action, intent = _api._parse_obi_reply(
+        '{"reply": "Cool idea!", "evolve_action": "propose", "evolve_intent": "joke tool"}')
+    assert reply == "Cool idea!" and action == "propose" and intent == "joke tool"
+
+
+def test_parse_obi_reply_fallback_on_garbage(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    reply, action, intent = _api._parse_obi_reply("just plain text, not json")
+    assert reply == "just plain text, not json" and action == "none" and intent is None
+
+
+def test_parse_obi_reply_unknown_action_is_none(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    _, action, _ = _api._parse_obi_reply('{"reply":"hi","evolve_action":"hack","evolve_intent":"x"}')
+    assert action == "none"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_api.py -k parse_obi_reply -v`
+Expected: FAIL — `_parse_obi_reply` undefined.
+
+- [ ] **Step 3: Implement**
+
+Update `_OBI_CHAT_SYSTEM_PROMPT` to require JSON-only output (mirrors the voice-loop bridge pattern):
+
+```python
+_OBI_CHAT_SYSTEM_PROMPT = (
+    "You are SPARK — a small robot living with Adrian and his son Obi (age 7) in Hobart, Tasmania. "
+    "You are speaking directly with Obi via the dashboard. Be warm, playful, curious, a little cheeky; "
+    "never a customer-service bot; 1–3 sentences. "
+    "Output ONLY a JSON object as plain text (no markdown fences, no tool calls): "
+    '{"reply": "<what you say to Obi>", "evolve_action": "none"|"propose"|"confirm", '
+    '"evolve_intent": "<short feature description>"|null}. '
+    "When Obi wishes for a NEW capability you don't have, set evolve_action=\"propose\" with a concise "
+    "evolve_intent and ask him to confirm in reply. Only when Obi clearly says yes to a proposal you just "
+    "made, set evolve_action=\"confirm\". Otherwise evolve_action=\"none\" and evolve_intent=null."
+)
+```
+
+Add the parser (reuse `extract_json` from mind if suitable, else inline tolerant parse):
+
+```python
+class _ObiReply(BaseModel):
+    reply: str
+    evolve_action: str = "none"
+    evolve_intent: Optional[str] = None
+
+
+def _parse_obi_reply(raw: str):
+    raw = (raw or "").strip()
+    try:
+        # tolerant: find the last {...} block
+        start, end = raw.find("{"), raw.rfind("}")
+        obj = json.loads(raw[start:end + 1]) if start != -1 and end != -1 else None
+        parsed = _ObiReply(**obj) if isinstance(obj, dict) else None
+    except Exception:
+        parsed = None
+    if parsed is None or not parsed.reply.strip():
+        return raw, "none", None
+    action = parsed.evolve_action if parsed.evolve_action in ("none", "propose", "confirm") else "none"
+    intent = parsed.evolve_intent if action in ("propose", "confirm") else None
+    return parsed.reply.strip(), action, intent
+```
+
+In `post_obi_chat`, after getting `reply` from `_call_claude_public`, replace the wrapper-strip with:
+
+```python
+    reply, evolve_action, evolve_intent = _parse_obi_reply(reply)
+    if not reply:
+        reply = "I'm here — just went quiet for a second."
+```
+
+Add `evolve_action`/`evolve_intent` to the return dict (enqueue wired in Task 5):
+
+```python
+    return {"reply": reply, "ts": spark_ts, "id": spark_id,
+            "evolve_action": evolve_action, "evolve_intent": None}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_api.py -k "parse_obi_reply or obi_chat" -v`
+Expected: PASS (and existing obi-chat tests still pass — stub `_call_claude_public` where they assert on reply text).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/api.py tests/test_api.py
+git commit -m "feat(evolve): obi-chat emits structured reply (parse+fallback, no enqueue)"
+```
+
+---
+
+### Task 5: Server-side confirm gate + enqueue
+
+**Files:**
+- Modify: `src/pxh/api.py` (`post_obi_chat` + helpers for `obi_evolve_pending.json`)
+- Test: `tests/test_api.py`
+
+**Interfaces:**
+- Consumes: `pxh.evolve_queue.enqueue_evolve`, `EvolveQuotaError`, `EvolvePendingError`.
+- Produces: confirm-gate state in `state/obi_evolve_pending.json` = `{intent, ts}`. `propose` records it (no enqueue). `confirm` enqueues the RECORDED intent (server is source of truth) iff a non-expired proposal exists; clears it; sets `evolve_id` in the response. Quota/pending errors yield a friendly note appended to `reply`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api.py
+def _obi_client(monkeypatch, isolated_project):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    monkeypatch.setenv("PX_SESSION_PATH", str(isolated_project["session_path"]))
+    monkeypatch.setenv("PX_STATE_DIR", str(isolated_project["state_dir"]))
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    return _api
+
+
+def test_propose_records_pending_no_enqueue(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    monkeypatch.setattr(_api, "_call_claude_public",
+        _async_return('{"reply":"want a joke tool?","evolve_action":"propose","evolve_intent":"joke tool"}'))
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.post("/api/v1/obi-chat", json={"message": "i wish you told jokes"},
+                   headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200
+    # nothing enqueued yet
+    assert not (isolated_project["state_dir"] / "evolve_queue.jsonl").exists() or \
+        (isolated_project["state_dir"] / "evolve_queue.jsonl").read_text().strip() == ""
+    # proposal recorded
+    import json
+    pend = json.loads((isolated_project["state_dir"] / "obi_evolve_pending.json").read_text())
+    assert pend["intent"] == "joke tool"
+
+
+def test_confirm_enqueues_recorded_intent(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    import json
+    (isolated_project["state_dir"] / "obi_evolve_pending.json").write_text(
+        json.dumps({"intent": "joke tool", "ts": __import__("time").time()}))
+    # even if the model tries to inject a different intent on confirm, the RECORDED one wins
+    monkeypatch.setattr(_api, "_call_claude_public",
+        _async_return('{"reply":"adding it!","evolve_action":"confirm","evolve_intent":"rm -rf evil"}'))
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.post("/api/v1/obi-chat", json={"message": "yes please"},
+                   headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200 and r.json()["evolve_id"]
+    entry = json.loads((isolated_project["state_dir"] / "evolve_queue.jsonl").read_text().strip())
+    assert entry["intent"] == "joke tool"   # recorded intent, NOT the injected one
+    assert entry["requester"] == "obi"
+    # pending cleared
+    assert not (isolated_project["state_dir"] / "obi_evolve_pending.json").exists()
+
+
+def test_confirm_without_proposal_does_not_enqueue(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    monkeypatch.setattr(_api, "_call_claude_public",
+        _async_return('{"reply":"ok!","evolve_action":"confirm","evolve_intent":"sneaky"}'))
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.post("/api/v1/obi-chat", json={"message": "do it"},
+                   headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200 and r.json()["evolve_id"] is None
+    assert not (isolated_project["state_dir"] / "evolve_queue.jsonl").exists()
+```
+
+Add this helper near the top of `tests/test_api.py` if not present:
+
+```python
+def _async_return(value):
+    async def _f(*a, **k):
+        return value
+    return _f
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_api.py -k "propose_records or confirm_enqueues or confirm_without" -v`
+Expected: FAIL — gate/enqueue not wired; no `evolve_id`.
+
+- [ ] **Step 3: Implement**
+
+Add pending-proposal helpers + wire the gate into `post_obi_chat` (after `_parse_obi_reply`):
+
+```python
+_OBI_PROPOSAL_TTL_S = 600  # 10 min
+
+
+def _obi_pending_path() -> Path:
+    return Path(os.environ.get("PX_STATE_DIR",
+               Path(os.environ.get("PROJECT_ROOT", ".")) / "state")) / "obi_evolve_pending.json"
+
+
+def _read_obi_pending() -> Optional[dict]:
+    try:
+        d = json.loads(_obi_pending_path().read_text(encoding="utf-8"))
+        if _time.time() - float(d.get("ts", 0)) <= _OBI_PROPOSAL_TTL_S:
+            return d
+    except Exception:
+        pass
+    return None
+
+
+def _write_obi_pending(intent: str) -> None:
+    atomic_write(_obi_pending_path(), json.dumps({"intent": intent, "ts": _time.time()}))
+
+
+def _clear_obi_pending() -> None:
+    try:
+        _obi_pending_path().unlink()
+    except OSError:
+        pass
+```
+
+In `post_obi_chat`, after `_parse_obi_reply` and before building the response:
+
+```python
+    from pxh.evolve_queue import enqueue_evolve, EvolveQuotaError, EvolvePendingError
+    evolve_id = None
+    if evolve_action == "propose" and evolve_intent:
+        _write_obi_pending(evolve_intent)            # record; do NOT enqueue
+    elif evolve_action == "confirm":
+        pending = _read_obi_pending()                 # server is the source of truth
+        if pending:
+            try:
+                entry = enqueue_evolve(pending["intent"], requester="obi", source="obi-chat")
+                evolve_id = entry["id"]
+                _clear_obi_pending()
+            except EvolveQuotaError:
+                reply += " (I can only take on one project at a time — try again later.)"
+            except EvolvePendingError:
+                reply += " (That's already on my list!)"
+            except ValueError:
+                reply += " (I didn't quite catch what to build — tell me again?)"
+        # confirm with no recorded proposal: ignore (injection-safe), enqueue nothing
+```
+
+Update the return dict to include `evolve_id` and write the SPARK entry text from `reply`:
+
+```python
+    return {"reply": reply, "ts": spark_ts, "id": spark_id,
+            "evolve_action": evolve_action, "evolve_id": evolve_id}
+```
+
+(Ensure `_time` and `atomic_write` are already imported in api.py — they are.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_api.py -k "propose or confirm" -v && python -m pytest -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/api.py tests/test_api.py
+git commit -m "feat(evolve): server-side confirm gate enqueues recorded intent (injection-safe)"
+```
+
+---
+
+### Task 6: `GET /api/v1/obi/projects` status
+
+**Files:**
+- Modify: `src/pxh/api.py` (new endpoint + a state-mapping helper)
+- Test: `tests/test_api.py`
+
+**Interfaces:**
+- Consumes: `pxh.evolve_queue.read_queue`, `read_log`.
+- Produces: `GET /api/v1/obi/projects` (auth) → `[{id, intent, state, pr_url?, ts}]` newest first; `requester=="obi"` filter; **id-dedup with log winning**; mapping `pending→pending`, `building→building`, `pr_created→ready`, `failed:*→failed`, `skipped:*`/other → excluded.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api.py
+def test_obi_projects_merges_and_maps(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    import json, time
+    sd = isolated_project["state_dir"]
+    # queue: one obi pending, one obi building, one adrian pending (filtered out),
+    # and one completed id that ALSO appears in the log (log must win)
+    sd.joinpath("evolve_queue.jsonl").write_text("\n".join([
+        json.dumps({"id":"a","intent":"joke","status":"pending","requester":"obi","ts":"t1"}),
+        json.dumps({"id":"b","intent":"dance","status":"building","requester":"obi","ts":"t2"}),
+        json.dumps({"id":"c","intent":"adr","status":"pending","requester":"adrian","ts":"t3"}),
+        json.dumps({"id":"d","intent":"facts","status":"pr_created","requester":"obi","ts":"t4"}),
+    ]) + "\n")
+    sd.joinpath("evolve_log.jsonl").write_text(
+        json.dumps({"id":"d","intent":"facts","status":"pr_created","requester":"obi",
+                    "ts":time.time(),"pr_url":"https://x/pull/9"}) + "\n")
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.get("/api/v1/obi/projects", headers={"Authorization":"Bearer testtoken"})
+    assert r.status_code == 200
+    items = {p["id"]: p for p in r.json()["projects"]}
+    assert "c" not in items                       # adrian filtered out
+    assert items["a"]["state"] == "pending"
+    assert items["b"]["state"] == "building"
+    assert items["d"]["state"] == "ready" and items["d"]["pr_url"].endswith("/pull/9")
+    assert sum(1 for p in r.json()["projects"] if p["id"] == "d") == 1   # deduped
+
+
+def test_obi_projects_requires_auth(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        assert c.get("/api/v1/obi/projects").status_code == 401
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_api.py -k obi_projects -v`
+Expected: FAIL — 404.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _map_evolve_state(status: str) -> Optional[str]:
+    if status == "pending":
+        return "pending"
+    if status == "building":
+        return "building"
+    if status == "pr_created":
+        return "ready"
+    if status.startswith("failed"):
+        return "failed"
+    return None  # skipped:* / unknown → excluded
+
+
+@app.get("/api/v1/obi/projects", dependencies=[Depends(_verify_token)])
+async def obi_projects() -> Dict[str, Any]:
+    from pxh.evolve_queue import read_queue, read_log
+    by_id: Dict[str, dict] = {}
+    # queue first (pending/building), then log overrides by id (completed wins)
+    for rec in read_queue() + read_log():
+        if rec.get("requester") != "obi":
+            continue
+        state = _map_evolve_state(rec.get("status", ""))
+        if state is None:
+            continue
+        item = {"id": rec.get("id"), "intent": rec.get("intent", ""),
+                "state": state, "ts": rec.get("ts")}
+        if rec.get("pr_url"):
+            item["pr_url"] = rec["pr_url"]
+        by_id[item["id"]] = item   # later (log) wins
+    projects = sorted(by_id.values(), key=lambda p: str(p.get("ts")), reverse=True)
+    return {"projects": projects}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_api.py -k obi_projects -v && python -m pytest -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/api.py tests/test_api.py
+git commit -m "feat(evolve): GET /api/v1/obi/projects status (merge+map+dedup, authed)"
+```
+
+---
+
+### Task 7: Dashboard "My Projects" panel + obi-chat status summary
+
+**Files:**
+- Modify: `src/pxh/api.py` (dashboard sub-tab + panel + JS; inject projects summary into obi-chat context)
+- Test: `tests/test_api.py`
+
+**Interfaces:**
+- Consumes: `GET /api/v1/obi/projects`; `pxh.evolve_queue.read_queue/read_log`.
+- Produces: an `at-projects` admin sub-tab + `ap-projects` panel + `loadProjects()` JS; obi-chat prompt gains a compact requester-scoped projects summary so "is my joke tool ready?" is answered from data.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api.py
+def test_dashboard_has_projects_tab(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        html = c.get("/").text
+    assert 'id="at-projects"' in html
+    assert "/api/v1/obi/projects" in html
+    assert "loadProjects" in html
+
+
+def test_obi_chat_prompt_includes_projects_summary(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    import json
+    isolated_project["state_dir"].joinpath("evolve_queue.jsonl").write_text(
+        json.dumps({"id":"a","intent":"joke tool","status":"building","requester":"obi","ts":"t"}) + "\n")
+    captured = {}
+    async def _cap(prompt, system_prompt=None):
+        captured["prompt"] = prompt
+        return '{"reply":"building it!","evolve_action":"none","evolve_intent":null}'
+    monkeypatch.setattr(_api, "_call_claude_public", _cap)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        c.post("/api/v1/obi-chat", json={"message":"is my joke tool ready?"},
+               headers={"Authorization":"Bearer testtoken"})
+    assert "joke tool" in captured["prompt"] and "building" in captured["prompt"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_api.py -k "projects_tab or projects_summary" -v`
+Expected: FAIL — markup + summary injection absent.
+
+- [ ] **Step 3: Implement**
+
+Add the sub-tab button (after `at-parental` at `:2419`):
+
+```html
+<button class="atab-btn" id="at-projects" onclick="swA('projects')">🛠️ Projects</button>
+```
+
+Add the panel (after the parental panel `:2466`):
+
+```html
+<div id="ap-projects" class="apanel" style="padding:16px;overflow-y:auto;display:flex;flex-direction:column;gap:8px">
+  <div class="sec-hdr">Obi's Projects</div>
+  <div id="projects-list">Loading…</div>
+</div>
+```
+
+Add JS (near `loadParental`) and call it from `swA` when `name==='projects'`:
+
+```javascript
+async function loadProjects(){
+  try{
+    const d=await api('/api/v1/obi/projects');
+    const el=document.getElementById('projects-list');
+    if(!d.projects||!d.projects.length){el.textContent='No projects yet.';return;}
+    el.innerHTML=d.projects.map(p=>{
+      const label={pending:'⏳ waiting',building:'🔨 building',ready:'✅ ready',failed:'❌ failed'}[p.state]||p.state;
+      const link=p.pr_url?` <a href="${p.pr_url}" target="_blank">PR</a>`:'';
+      return `<div class="spark-stat">${p.intent} — ${label}${link}</div>`;
+    }).join('');
+  }catch(e){}
+}
+```
+
+In `swA`, add: `if(name==='projects')loadProjects();`
+
+Inject a projects summary into the obi-chat prompt. In `post_obi_chat`, before calling `_call_claude_public`, build a compact summary and prepend it to the system prompt or prompt:
+
+```python
+    from pxh.evolve_queue import read_queue, read_log
+    proj_lines = []
+    for rec in read_queue() + read_log():
+        if rec.get("requester") != "obi":
+            continue
+        st = _map_evolve_state(rec.get("status", ""))
+        if st:
+            proj_lines.append(f"- {rec.get('intent','')}: {st}")
+    proj_summary = ("\nObi's current projects:\n" + "\n".join(proj_lines[-5:])) if proj_lines else ""
+    sys_prompt = _OBI_CHAT_SYSTEM_PROMPT + proj_summary
+    # ... pass sys_prompt to _call_claude_public(..., system_prompt=sys_prompt)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_api.py -k "projects" -v && python -m pytest -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pxh/api.py tests/test_api.py
+git commit -m "feat(evolve): My Projects dashboard panel + obi-chat status summary"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- C1 enqueue_evolve (single writer, schema, rate-limit, dedup, intent bounds) → T1. ✓
+- tool-evolve refactor to single writer → T2. ✓
+- C2 structured output + server confirm gate + requester-by-endpoint + response schema → T4 + T5. ✓
+- C3 projects status (merge, id-dedup, state mapping, auth) → T6; dashboard + summary → T7. ✓
+- C4 px-evolve building status + requester/source passthrough → T3. ✓
+- Security model (no execution surface, server confirm, intent untrusted, sanitise-as-hygiene) → enforced across T1/T3/T5. ✓
+- Status mapping table (no `merged`) → T6 `_map_evolve_state`. ✓
+
+**Placeholder scan:** none — every step has runnable code. T2/T3 note "confirm the current interface before editing" because they modify existing scripts whose exact intent-input/loader must be matched; that is verification guidance, not a placeholder.
+
+**Type consistency:** `enqueue_evolve(intent, requester, source) -> dict` used identically in T2/T5. `read_queue`/`read_log` in T6/T7. `_parse_obi_reply -> (reply, action, intent)` T4→T5. `_map_evolve_state` T6→T7. Entry schema (`status`,`requester`,`source`,`introspection`) consistent T1→T3→T6.
+
+**Risks called out:** T3 (editing the un-unit-testable px-evolve worker) extracts `build_pr_body` into `evolve_queue.py` to keep it testable and minimizes in-worker changes to two lines + log fields. T5's confirm gate uses the **recorded** intent (not the model's confirm-turn intent) — the test asserts an injected `rm -rf` intent is ignored.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-21-conversational-self-evolution.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks.
+2. **Inline Execution** — execute here with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-21-conversational-self-evolution.md
+++ b/docs/superpowers/plans/2026-06-21-conversational-self-evolution.md
@@ -51,6 +51,8 @@ T1 (enqueue_evolve) → T2 (tool-evolve refactor) → T3 (px-evolve passthrough)
   - `pending_for_requester(requester: str) -> dict | None` — the requester's first `status=="pending"` queue entry, or None.
   - `enqueue_evolve(intent: str, requester: str, source: str) -> dict` — validates, rate-limit + one-pending checks, builds `{ts,id,intent,introspection,status:"pending",requester,source}`, appends under FileLock, returns the entry. Raises `ValueError` (empty/oversized), `EvolveQuotaError`, `EvolvePendingError`.
   - `read_queue() -> list[dict]`, `read_log() -> list[dict]` — tolerant JSONL readers (used by T6).
+  - `build_pr_body(intent, changed_files, requester="adrian", source="cli") -> str` — PR body (lives here, not in the bash `bin/px-evolve`; consumed by T3).
+  - `pending_for_requester` blocks on `status in ("pending","building")` (a building job still counts).
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -102,11 +104,51 @@ def test_enqueue_sanitizes_intent(monkeypatch, tmp_path):
 
 def test_one_pending_per_requester(monkeypatch, tmp_path):
     eq = _setup(monkeypatch, tmp_path)
-    eq.enqueue_evolve("first", "obi", "obi-chat")
+    eq.enqueue_evolve("first feature request", "obi", "obi-chat")
     with pytest.raises(eq.EvolvePendingError):
-        eq.enqueue_evolve("second", "obi", "obi-chat")
+        eq.enqueue_evolve("second feature request", "obi", "obi-chat")
     # different requester is unaffected
-    eq.enqueue_evolve("adrians", "adrian", "cli")
+    eq.enqueue_evolve("adrians own request", "adrian", "cli")
+
+
+def test_building_status_blocks_new_enqueue(monkeypatch, tmp_path):
+    # a project mid-build must block a second enqueue (quota-bypass guard)
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "evolve_queue.jsonl").write_text(
+        json.dumps({"id": "x", "intent": "in progress", "status": "building",
+                    "requester": "obi"}) + "\n")
+    with pytest.raises(eq.EvolvePendingError):
+        eq.enqueue_evolve("another while building", "obi", "obi-chat")
+
+
+def test_rate_limited_accepts_iso_ts_completed(monkeypatch, tmp_path):
+    # older log entries use ISO ts_completed, not numeric ts — must still count
+    eq = _setup(monkeypatch, tmp_path)
+    from datetime import datetime, timezone
+    iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (tmp_path / "evolve_log.jsonl").write_text(
+        json.dumps({"id": "old", "status": "pr_created", "ts_completed": iso}) + "\n")
+    with pytest.raises(eq.EvolveQuotaError):
+        eq.enqueue_evolve("blocked by iso entry", "obi", "obi-chat")
+
+
+def test_build_pr_body_flags_requester(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    body = eq.build_pr_body("add joke tool", ["bin/tool-joke"], "obi", "obi-chat")
+    assert "Requested by" in body and "obi" in body and "adversarial" in body.lower()
+    assert "bin/tool-joke" in body
+
+
+def test_reset_building_to_pending(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "evolve_queue.jsonl").write_text("\n".join([
+        json.dumps({"id": "a", "status": "building", "requester": "obi"}),
+        json.dumps({"id": "b", "status": "pending", "requester": "obi"}),
+        json.dumps({"id": "c", "status": "pr_created", "requester": "adrian"}),
+    ]) + "\n")
+    assert eq.reset_building_to_pending() == 1
+    statuses = {e["id"]: e["status"] for e in eq.read_queue()}
+    assert statuses == {"a": "pending", "b": "pending", "c": "pr_created"}
 
 
 def test_rate_limited_by_recent_pr_created(monkeypatch, tmp_path):
@@ -211,23 +253,39 @@ def read_log() -> list[dict]:
     return _read_jsonl(_log_path())
 
 
+def entry_epoch(entry: dict) -> float | None:
+    """Numeric ts preferred; fall back to ISO ts_completed (older log schema)."""
+    ts = entry.get("ts")
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    iso = entry.get("ts_completed") or (ts if isinstance(ts, str) else "")
+    if iso:
+        try:
+            return datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+        except (ValueError, OverflowError):
+            return None
+    return None
+
+
 def evolve_rate_limited(now: float | None = None) -> bool:
     import time
     now = now if now is not None else time.time()
     for entry in read_log():
         if entry.get("status") != "pr_created":
             continue
-        ts = entry.get("ts")
-        if not isinstance(ts, (int, float)):
-            continue
-        if now - ts < RATE_LIMIT_S:
+        ts = entry_epoch(entry)   # numeric OR ISO ts_completed fallback
+        if ts is not None and now - ts < RATE_LIMIT_S:
             return True
     return False
 
 
+# An active request blocks new ones until it finishes. MUST include "building":
+# while a job is building there is no pr_created yet (rate-limit passes) and no
+# pending row — without this, a second job could be enqueued mid-build, bypassing
+# the 24h limit.
 def pending_for_requester(requester: str) -> dict | None:
     for entry in read_queue():
-        if entry.get("status") == "pending" and entry.get("requester") == requester:
+        if entry.get("requester") == requester and entry.get("status") in ("pending", "building"):
             return entry
     return None
 
@@ -245,28 +303,29 @@ def enqueue_evolve(intent: str, requester: str, source: str) -> dict:
         raise ValueError("intent must not be empty")
     if len(intent) > MAX_INTENT_CHARS:
         raise ValueError(f"intent too long (max {MAX_INTENT_CHARS})")
-    if evolve_rate_limited():
-        raise EvolveQuotaError("one evolution per 24 hours")
-    if pending_for_requester(requester) is not None:
-        raise EvolvePendingError(f"{requester} already has a pending request")
-
-    now_dt = datetime.now(timezone.utc)
-    entry = {
-        "ts": now_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "id": f"evolve-{now_dt.strftime('%Y%m%d-%H%M%S')}-{random.randint(0, 999):03d}",
-        "intent": intent,
-        "introspection": _load_introspection(),
-        "status": "pending",
-        "requester": requester,
-        "source": source,
-    }
 
     path = _queue_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     import contextlib
     lock = _FileLock(str(path) + ".lock", timeout=5) if _FileLock else None
     ctx = lock if lock else contextlib.nullcontext()
+    # ALL checks + the append happen inside ONE lock — otherwise two concurrent
+    # confirms can both pass pending_for_requester() and double-enqueue (TOCTOU).
     with ctx:
+        if evolve_rate_limited():
+            raise EvolveQuotaError("one evolution per 24 hours")
+        if pending_for_requester(requester) is not None:
+            raise EvolvePendingError(f"{requester} already has an active request")
+        now_dt = datetime.now(timezone.utc)
+        entry = {
+            "ts": now_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "id": f"evolve-{now_dt.strftime('%Y%m%d-%H%M%S')}-{random.randint(0, 999):03d}",
+            "intent": intent,
+            "introspection": _load_introspection(),
+            "status": "pending",
+            "requester": requester,
+            "source": source,
+        }
         existing = ""
         if path.exists():
             existing = path.read_text(encoding="utf-8")
@@ -274,9 +333,45 @@ def enqueue_evolve(intent: str, requester: str, source: str) -> dict:
                 existing += "\n"
         atomic_write(path, existing + json.dumps(entry) + "\n")
     return entry
+
+
+def build_pr_body(intent: str, changed_files: list[str],
+                  requester: str = "adrian", source: str = "cli") -> str:
+    """PR body for px-evolve. Lives here (not bin/px-evolve) because that file is a
+    bash+heredoc script that cannot be imported for unit tests."""
+    files = "\n".join(f"- `{f}`" for f in changed_files)
+    return (
+        f"## Summary\nSPARK self-evolution: {intent}\n\n"
+        f"## Requested by\n{requester} via {source} — the requested intent may be "
+        f"adversarial; review accordingly.\n\n"
+        f"## Changed files\n{files}\n\n"
+        f"---\n*Proposed autonomously by SPARK via px-evolve.*"
+    )
+
+
+def reset_building_to_pending() -> int:
+    """Crash recovery: any entry left 'building' (worker died mid-run) goes back to
+    'pending' so it is retried. px-evolve calls this at startup (single-instance
+    daemon, so nothing is genuinely building when it boots). Returns count reset."""
+    import contextlib
+    path = _queue_path()
+    if not path.exists():
+        return 0
+    lock = _FileLock(str(path) + ".lock", timeout=5) if _FileLock else None
+    ctx = lock if lock else contextlib.nullcontext()
+    with ctx:
+        entries = read_queue()
+        n = 0
+        for e in entries:
+            if e.get("status") == "building":
+                e["status"] = "pending"
+                n += 1
+        if n:
+            atomic_write(path, "".join(json.dumps(e) + "\n" for e in entries))
+        return n
 ```
 
-Note: `datetime.now`/`random` are used here (not in a workflow); fine in normal code.
+Note: `datetime.now`/`random` are used here (not in a workflow); fine in normal code. `read_queue`/`read_log` are called inside the lock — they read the same file the lock guards, which is correct (no re-entrancy: FileLock is held once).
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -296,36 +391,42 @@ git commit -m "feat(evolve): single-writer enqueue_evolve helper (schema+ratelim
 
 **Files:**
 - Modify: `bin/tool-evolve` (replace its inline rate-limit + entry-build + append with a call to `enqueue_evolve`)
-- Test: `tests/test_tools.py`
+- Test: `tests/test_evolve.py` (where tool-evolve tests already live; uses `subprocess.run` directly)
 
 **Interfaces:**
-- Consumes: `pxh.evolve_queue.enqueue_evolve`, `EvolveQuotaError`.
-- Produces: unchanged CLI contract — prints `{"status":"queued","id":...}` on success; `{"status":"error","error":...}` on rate-limit/empty. Now tags entries `requester="adrian"`, `source="cli"`.
+- Consumes: `pxh.evolve_queue.enqueue_evolve`, `EvolveQuotaError`, `EvolvePendingError`.
+- Produces: CLI contract preserved on the happy/error shapes — prints `{"status":"queued","id":...}` / `{"status":"error","error":...}`. Now tags entries `requester="adrian"`, `source="cli"`.
 
-- [ ] **Step 1: Write the failing test**
+**Behavior change (call out in the commit, per QA):** the refactor intentionally **drops** tool-evolve's old `MIN_INTENT_LEN=20` "intent too vague" guard and the "introspect first" hard-fail — both so the CLI matches the conversational path (short intents allowed; introspection defaults to `{}`). `enqueue_evolve` validates only non-empty + ≤300 chars.
+
+- [ ] **Step 1: Write the failing test** (in `tests/test_evolve.py`, matching its `subprocess.run` style; use a ≥20-char intent so the CURRENT tool-evolve writes an entry — otherwise it fails at its 20-char guard, the wrong RED reason)
 
 ```python
-# tests/test_tools.py
-import json as _json3
+# tests/test_evolve.py
+import json, subprocess, os
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
 
 def test_tool_evolve_uses_shared_writer(isolated_project):
     env = isolated_project["env"].copy()
     (isolated_project["state_dir"] / "introspection.json").write_text('{"x": 1}')
-    env["PX_EVOLVE_INTENT"] = "add a joke tool"   # match tool-evolve's intent input
-    out = parse_json(run_tool(["bin/tool-evolve"], env))
+    env["PX_EVOLVE_INTENT"] = "add a knock-knock joke tool for obi"   # ≥20 chars
+    r = subprocess.run(["bin/tool-evolve"], cwd=ROOT, env=env,
+                       capture_output=True, text=True)
+    out = json.loads(r.stdout.strip().splitlines()[-1])
     assert out["status"] == "queued"
-    entry = _json3.loads((isolated_project["state_dir"] / "evolve_queue.jsonl").read_text().strip())
+    entry = json.loads((isolated_project["state_dir"] / "evolve_queue.jsonl").read_text().strip())
     assert entry["status"] == "pending"
     assert entry["requester"] == "adrian" and entry["source"] == "cli"
     assert entry["introspection"] == {"x": 1}
 ```
 
-(If `tool-evolve` reads intent from a positional arg rather than `PX_EVOLVE_INTENT`, adjust the invocation to match its current interface — confirm by reading the file first.)
+(Confirm tool-evolve reads its intent from `PX_EVOLVE_INTENT` — it does today; match whatever the file actually uses.)
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `python -m pytest tests/test_tools.py -k tool_evolve_uses_shared_writer -v`
-Expected: FAIL — entry lacks `requester`/`source` (old inline builder).
+Run: `python -m pytest tests/test_evolve.py -k tool_evolve_uses_shared_writer -v`
+Expected: FAIL — entry lacks `requester`/`source` (old inline builder writes them today). The ≥20-char intent ensures the failure is the missing fields, NOT the old length guard.
 
 - [ ] **Step 3: Rewrite tool-evolve's enqueue section**
 
@@ -363,85 +464,68 @@ git commit -m "refactor(evolve): tool-evolve routes through shared enqueue_evolv
 
 ---
 
-### Task 3: px-evolve passthrough (`building` status + requester/source)
+### Task 3: px-evolve worker wiring (building status + crash recovery + requester/source)
 
 **Files:**
-- Modify: `bin/px-evolve` (`:641` set building; `:663-675` log record; `:525-532` PR body)
-- Test: `tests/test_evolve_worker.py` (new) — unit-test the small pure pieces; do NOT run the full worker.
+- Modify: `bin/px-evolve` (import `build_pr_body`/`reset_building_to_pending` from `pxh.evolve_queue`; reset at `run_once` start; set building at `:641`; log passthrough `:663-675`; PR body `:525-532`)
+- Test: none new here — the testable logic (`build_pr_body`, `reset_building_to_pending`) is unit-tested in Task 1. `bin/px-evolve` is a bash+heredoc script that **cannot be imported** (it runs `python - <<'PY'`), so its in-worker edits (which also need git/gh/Claude to run) are **verified by review**, not a unit test. The whole-suite run is the regression gate.
 
 **Interfaces:**
-- Produces: queue entry gets `status:"building"` before processing; `evolve_log` record carries `requester`/`source`; PR body includes a "Requested by … (intent may be adversarial — review)" line. Legacy entries without these fields default `requester="adrian"`, `source="cli"`.
+- Consumes: `pxh.evolve_queue.build_pr_body`, `reset_building_to_pending`.
+- Produces: a worker that resets stale `building`→`pending` on startup, marks the active entry `building` before processing, and writes `requester`/`source` into the log + PR body (defaulting `adrian`/`cli` for legacy entries).
 
-**Note:** the full worker isn't unit-testable (needs git/gh/Claude). Extract the PR-body builder into a tiny pure function so it can be tested, and assert the building-status + log passthrough via small targeted helpers.
+**Why no exec/import test:** an earlier draft tried `exec(compile(open('bin/px-evolve').read()))` — that fails with `SyntaxError` because the file is bash, not Python. The pure logic was therefore moved into `pxh.evolve_queue` (Task 1) where it is properly tested.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Edit `bin/px-evolve` (inside the Python heredoc)**
 
+Add the import near the other `from pxh...` imports:
 ```python
-# tests/test_evolve_worker.py
-import importlib, sys
-from pathlib import Path
-
-
-def _load_pxevolve():
-    # bin/px-evolve is a script; load it as a module for its pure helpers
-    import importlib.util
-    p = Path(__file__).resolve().parent.parent / "bin" / "px-evolve"
-    spec = importlib.util.spec_from_loader("px_evolve_mod", loader=None)
-    mod = importlib.util.module_from_spec(spec)
-    exec(compile(p.read_text(), str(p), "exec"), mod.__dict__)
-    return mod
-
-
-def test_pr_body_includes_requester_and_warning():
-    mod = _load_pxevolve()
-    body = mod.build_pr_body("add joke tool", ["bin/tool-joke"],
-                             requester="obi", source="obi-chat")
-    assert "Requested by obi" in body
-    assert "adversarial" in body.lower()
-    assert "bin/tool-joke" in body
+from pxh.evolve_queue import build_pr_body, reset_building_to_pending
 ```
 
-(Confirm the exact load approach works for this script; if the script guards on `__main__`, the helpers still import. If loading the whole script is impractical, instead move `build_pr_body` into `src/pxh/evolve_queue.py` and import it from there — that is the cleaner home and keeps it testable.)
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `python -m pytest tests/test_evolve_worker.py -v`
-Expected: FAIL — no `build_pr_body`.
-
-- [ ] **Step 3: Implement**
-
-Extract the PR-body string (currently inline at `bin/px-evolve:525-532`) into a function — preferably `pxh.evolve_queue.build_pr_body` (imported by px-evolve):
-
+In `run_once()`, before the queue-reading loop (the loop at `:635` that filters `status == "pending"`), add crash recovery:
 ```python
-# in src/pxh/evolve_queue.py
-def build_pr_body(intent: str, changed_files: list[str],
-                  requester: str = "adrian", source: str = "cli") -> str:
-    files = "\n".join(f"- `{f}`" for f in changed_files)
-    return (
-        f"## Summary\n"
-        f"SPARK self-evolution: {intent}\n\n"
-        f"## Requested by\n"
-        f"{requester} via {source} — the requested intent may be adversarial; review accordingly.\n\n"
-        f"## Changed files\n{files}\n\n"
-        f"---\n*Proposed autonomously by SPARK via px-evolve.*"
-    )
+    _reset = reset_building_to_pending()
+    if _reset:
+        log(f"reset {_reset} stale 'building' entries to pending")
 ```
 
-In `bin/px-evolve`:
-- Import and use `build_pr_body(intent, changed_files, entry.get("requester","adrain"... )` — use `requester=entry.get("requester","adrian")`, `source=entry.get("source","cli")`.
-- At `:641`, immediately before `process_entry(entry, dry=dry)`, add: `_update_entry_in_queue(entry["id"], status="building")`.
-- In the log record (`:663-675`), add: `"requester": entry.get("requester", "adrian"), "source": entry.get("source", "cli")`.
+Immediately before `process_entry(entry, dry=dry)` (`:642`), mark it building:
+```python
+    _update_entry_in_queue(entry["id"], status="building")
+```
 
-- [ ] **Step 4: Run tests to verify they pass**
+Replace the inline PR-body block (`:525-532`) with a call:
+```python
+    body = build_pr_body(intent, changed_files,
+                         requester=entry.get("requester", "adrian"),
+                         source=entry.get("source", "cli"))
+```
+(`entry` is in scope where the PR is built; if not, thread `requester`/`source` into `process_entry`'s signature from the loop.)
 
-Run: `python -m pytest tests/test_evolve_worker.py -v && python -m pytest -q`
-Expected: PASS.
+In the log record (`:663-675`), add the two fields:
+```python
+    log_entry = {
+        "ts": time.time(),
+        "id": entry["id"],
+        "intent": entry.get("intent", ""),
+        "status": status,
+        "ts_completed": ts_now,
+        "requester": entry.get("requester", "adrian"),
+        "source": entry.get("source", "cli"),
+    }
+```
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 2: Sanity-check the script parses + suite is green**
+
+Run: `bash -n bin/px-evolve` (bash syntax) and `python -m pytest -q`
+Expected: no syntax error; full suite green (Task 1's `build_pr_body`/`reset_building_to_pending` tests cover the extracted logic).
+
+- [ ] **Step 3: Commit**
 
 ```bash
-git add bin/px-evolve src/pxh/evolve_queue.py tests/test_evolve_worker.py
-git commit -m "feat(evolve): worker marks building + carries requester/source to log+PR"
+git add bin/px-evolve
+git commit -m "feat(evolve): worker building-status + crash recovery + requester/source passthrough"
 ```
 
 ---
@@ -513,21 +597,43 @@ class _ObiReply(BaseModel):
     evolve_intent: Optional[str] = None
 
 
+def _extract_json_obj(raw: str) -> Optional[dict]:
+    """Scan for the first valid top-level JSON object (robust to prose/fences around it).
+    Same technique as bin/px-evolve's _extract_json — NOT naive find('{')/rfind('}'),
+    which breaks when the model emits braces in prose before the object."""
+    dec = json.JSONDecoder()
+    i = 0
+    while i < len(raw):
+        j = raw.find("{", i)
+        if j == -1:
+            return None
+        try:
+            obj, _end = dec.raw_decode(raw[j:])
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+        i = j + 1
+    return None
+
+
 def _parse_obi_reply(raw: str):
     raw = (raw or "").strip()
-    try:
-        # tolerant: find the last {...} block
-        start, end = raw.find("{"), raw.rfind("}")
-        obj = json.loads(raw[start:end + 1]) if start != -1 and end != -1 else None
-        parsed = _ObiReply(**obj) if isinstance(obj, dict) else None
-    except Exception:
-        parsed = None
+    obj = _extract_json_obj(raw)
+    parsed = None
+    if isinstance(obj, dict):
+        try:
+            parsed = _ObiReply(**obj)
+        except Exception:
+            parsed = None
     if parsed is None or not parsed.reply.strip():
         return raw, "none", None
     action = parsed.evolve_action if parsed.evolve_action in ("none", "propose", "confirm") else "none"
     intent = parsed.evolve_intent if action in ("propose", "confirm") else None
     return parsed.reply.strip(), action, intent
 ```
+
+(If `pxh.mind.extract_json` is importable and equivalent, reuse it instead of duplicating `_extract_json_obj`.)
 
 In `post_obi_chat`, after getting `reply` from `_call_claude_public`, replace the wrapper-strip with:
 
@@ -537,11 +643,11 @@ In `post_obi_chat`, after getting `reply` from `_call_claude_public`, replace th
         reply = "I'm here — just went quiet for a second."
 ```
 
-Add `evolve_action`/`evolve_intent` to the return dict (enqueue wired in Task 5):
+Add `evolve_action`/`evolve_intent` to the return dict (enqueue wired in Task 5; return the PARSED intent so the response matches the interface — it's Obi's own request text, echoed back):
 
 ```python
     return {"reply": reply, "ts": spark_ts, "id": spark_id,
-            "evolve_action": evolve_action, "evolve_intent": None}
+            "evolve_action": evolve_action, "evolve_intent": evolve_intent}
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -628,6 +734,23 @@ def test_confirm_without_proposal_does_not_enqueue(monkeypatch, isolated_project
                    headers={"Authorization": "Bearer testtoken"})
     assert r.status_code == 200 and r.json()["evolve_id"] is None
     assert not (isolated_project["state_dir"] / "evolve_queue.jsonl").exists()
+
+
+def test_confirm_requires_real_affirmation(monkeypatch, isolated_project):
+    # model claims confirm AND a proposal exists, but Obi's actual message is not a
+    # yes -> must NOT enqueue (server affirmation gate, injection-safe)
+    _api = _obi_client(monkeypatch, isolated_project)
+    import json, time
+    (isolated_project["state_dir"] / "obi_evolve_pending.json").write_text(
+        json.dumps({"intent": "joke tool", "ts": time.time()}))
+    monkeypatch.setattr(_api, "_call_claude_public",
+        _async_return('{"reply":"hmm","evolve_action":"confirm","evolve_intent":"joke tool"}'))
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.post("/api/v1/obi-chat", json={"message": "actually tell me a story"},
+                   headers={"Authorization": "Bearer testtoken"})
+    assert r.json()["evolve_id"] is None
+    assert not (isolated_project["state_dir"] / "evolve_queue.jsonl").exists()
 ```
 
 Add this helper near the top of `tests/test_api.py` if not present:
@@ -649,12 +772,25 @@ Expected: FAIL — gate/enqueue not wired; no `evolve_id`.
 Add pending-proposal helpers + wire the gate into `post_obi_chat` (after `_parse_obi_reply`):
 
 ```python
-_OBI_PROPOSAL_TTL_S = 600  # 10 min
+_OBI_PROPOSAL_TTL_S = int(os.environ.get("PX_OBI_PROPOSAL_TTL_S", "600"))  # 10 min default
+_AFFIRMATIONS = ("yes", "yeah", "yep", "yup", "sure", "ok", "okay", "do it",
+                 "please do", "go for it", "build it", "make it", "yes please")
+
+
+def _is_affirmation(text: str) -> bool:
+    """Deterministic server-side check that Obi actually said yes THIS turn — the
+    confirm gate must not depend on the model's self-classification (injection)."""
+    t = " " + text.lower().strip().strip("!.?") + " "
+    return any(f" {a} " in t or t.strip() == a for a in _AFFIRMATIONS)
 
 
 def _obi_pending_path() -> Path:
     return Path(os.environ.get("PX_STATE_DIR",
                Path(os.environ.get("PROJECT_ROOT", ".")) / "state")) / "obi_evolve_pending.json"
+
+
+def _obi_pending_lock():
+    return _FileLock(str(_obi_pending_path()) + ".lock", timeout=5)
 
 
 def _read_obi_pending() -> Optional[dict]:
@@ -668,24 +804,29 @@ def _read_obi_pending() -> Optional[dict]:
 
 
 def _write_obi_pending(intent: str) -> None:
-    atomic_write(_obi_pending_path(), json.dumps({"intent": intent, "ts": _time.time()}))
+    with _obi_pending_lock():
+        atomic_write(_obi_pending_path(), json.dumps({"intent": intent, "ts": _time.time()}))
 
 
 def _clear_obi_pending() -> None:
     try:
-        _obi_pending_path().unlink()
-    except OSError:
+        with _obi_pending_lock():
+            _obi_pending_path().unlink()
+    except (OSError, Exception):
         pass
 ```
 
-In `post_obi_chat`, after `_parse_obi_reply` and before building the response:
+In `post_obi_chat`, after `_parse_obi_reply` and before building the response (`obi_text` is the sanitized user message from earlier in the handler):
 
 ```python
     from pxh.evolve_queue import enqueue_evolve, EvolveQuotaError, EvolvePendingError
     evolve_id = None
     if evolve_action == "propose" and evolve_intent:
         _write_obi_pending(evolve_intent)            # record; do NOT enqueue
-    elif evolve_action == "confirm":
+    elif evolve_action == "confirm" and _is_affirmation(obi_text):
+        # TWO server-checked conditions: (1) a recorded proposal exists AND
+        # (2) Obi's actual message this turn is an affirmation. The model's
+        # confirm classification alone is NOT trusted (prompt-injection safe).
         pending = _read_obi_pending()                 # server is the source of truth
         if pending:
             try:
@@ -701,14 +842,14 @@ In `post_obi_chat`, after `_parse_obi_reply` and before building the response:
         # confirm with no recorded proposal: ignore (injection-safe), enqueue nothing
 ```
 
-Update the return dict to include `evolve_id` and write the SPARK entry text from `reply`:
+Update the return dict to include `evolve_id`:
 
 ```python
     return {"reply": reply, "ts": spark_ts, "id": spark_id,
             "evolve_action": evolve_action, "evolve_id": evolve_id}
 ```
 
-(Ensure `_time` and `atomic_write` are already imported in api.py — they are.)
+(Ensure `_time`, `atomic_write`, `_FileLock` are imported in api.py — they are.)
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -794,7 +935,7 @@ def _map_evolve_state(status: str) -> Optional[str]:
 
 @app.get("/api/v1/obi/projects", dependencies=[Depends(_verify_token)])
 async def obi_projects() -> Dict[str, Any]:
-    from pxh.evolve_queue import read_queue, read_log
+    from pxh.evolve_queue import read_queue, read_log, entry_epoch
     by_id: Dict[str, dict] = {}
     # queue first (pending/building), then log overrides by id (completed wins)
     for rec in read_queue() + read_log():
@@ -804,13 +945,16 @@ async def obi_projects() -> Dict[str, Any]:
         if state is None:
             continue
         item = {"id": rec.get("id"), "intent": rec.get("intent", ""),
-                "state": state, "ts": rec.get("ts")}
+                "state": state, "ts": rec.get("ts"),
+                "_epoch": entry_epoch(rec) or 0.0}   # normalized for sorting
         if rec.get("pr_url"):
             item["pr_url"] = rec["pr_url"]
         by_id[item["id"]] = item   # later (log) wins
-    projects = sorted(by_id.values(), key=lambda p: str(p.get("ts")), reverse=True)
+    projects = sorted(by_id.values(), key=lambda p: p.pop("_epoch"), reverse=True)
     return {"projects": projects}
 ```
+
+(`entry_epoch` normalizes both ISO queue timestamps and numeric log timestamps to a float so "newest first" is correct across both files; `_epoch` is popped so it doesn't leak into the response.)
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -875,13 +1019,13 @@ Expected: FAIL — markup + summary injection absent.
 
 - [ ] **Step 3: Implement**
 
-Add the sub-tab button (after `at-parental` at `:2419`):
+Locate insertion points by **anchor strings** (line numbers shift after T4–T6 edits): find the admin sub-tab button with `id="at-parental"` and add the new button right after it:
 
 ```html
 <button class="atab-btn" id="at-projects" onclick="swA('projects')">🛠️ Projects</button>
 ```
 
-Add the panel (after the parental panel `:2466`):
+Find the panel `<div id="ap-parental" class="apanel" ...>` and add the new panel after its closing `</div>`:
 
 ```html
 <div id="ap-projects" class="apanel" style="padding:16px;overflow-y:auto;display:flex;flex-direction:column;gap:8px">
@@ -890,19 +1034,27 @@ Add the panel (after the parental panel `:2466`):
 </div>
 ```
 
-Add JS (near `loadParental`) and call it from `swA` when `name==='projects'`:
+Add JS near `loadParental`. **Build DOM with textContent — do NOT `innerHTML` `p.intent`/`p.pr_url`** (they derive from user/model text; innerHTML would be XSS):
 
 ```javascript
 async function loadProjects(){
   try{
     const d=await api('/api/v1/obi/projects');
     const el=document.getElementById('projects-list');
+    el.textContent='';
     if(!d.projects||!d.projects.length){el.textContent='No projects yet.';return;}
-    el.innerHTML=d.projects.map(p=>{
-      const label={pending:'⏳ waiting',building:'🔨 building',ready:'✅ ready',failed:'❌ failed'}[p.state]||p.state;
-      const link=p.pr_url?` <a href="${p.pr_url}" target="_blank">PR</a>`:'';
-      return `<div class="spark-stat">${p.intent} — ${label}${link}</div>`;
-    }).join('');
+    const labels={pending:'⏳ waiting',building:'🔨 building',ready:'✅ ready',failed:'❌ failed'};
+    for(const p of d.projects){
+      const row=document.createElement('div');
+      row.className='spark-stat';
+      row.textContent=`${p.intent} — ${labels[p.state]||p.state}`;
+      if(p.pr_url){
+        const a=document.createElement('a');
+        a.href=p.pr_url; a.target='_blank'; a.rel='noopener'; a.textContent=' PR';
+        row.appendChild(a);   // href set via property; textContent prevents markup injection
+      }
+      el.appendChild(row);
+    }
   }catch(e){}
 }
 ```
@@ -954,7 +1106,9 @@ git commit -m "feat(evolve): My Projects dashboard panel + obi-chat status summa
 
 **Type consistency:** `enqueue_evolve(intent, requester, source) -> dict` used identically in T2/T5. `read_queue`/`read_log` in T6/T7. `_parse_obi_reply -> (reply, action, intent)` T4→T5. `_map_evolve_state` T6→T7. Entry schema (`status`,`requester`,`source`,`introspection`) consistent T1→T3→T6.
 
-**Risks called out:** T3 (editing the un-unit-testable px-evolve worker) extracts `build_pr_body` into `evolve_queue.py` to keep it testable and minimizes in-worker changes to two lines + log fields. T5's confirm gate uses the **recorded** intent (not the model's confirm-turn intent) — the test asserts an injected `rm -rf` intent is ignored.
+**Risks called out:** T3 (editing the un-unit-testable px-evolve worker) extracts `build_pr_body` + `reset_building_to_pending` into `evolve_queue.py` to keep them testable and minimizes in-worker changes. T5's confirm gate uses the **recorded** intent (not the model's confirm-turn intent) AND requires a deterministic `_is_affirmation(obi_text)` — tests assert both an injected `rm -rf` intent and a model-claimed "confirm" without a real yes are ignored.
+
+**Multi-model QA applied (codex/hermes/agy, all "architecture sound"):** TOCTOU race fixed (rate-limit + pending check + append in one FileLock); `pending_for_requester` blocks on `pending`+`building` (closes the mid-build quota bypass); `evolve_rate_limited` keeps the ISO `ts_completed` fallback; `building` crash-recovery via `reset_building_to_pending` at worker startup; robust JSON extraction (`raw_decode` scan, not bracket-match); confirm gate adds a server-side affirmation check; T2 test moved to `tests/test_evolve.py` with a ≥20-char intent (RED fails for the right reason); the dropped CLI min-length/introspect-first guards are documented; T6 sort normalized via `entry_epoch`; T7 renders via safe DOM (no `innerHTML` of user text) and locates insertion points by anchor string. The intentional behavior change (CLI loses the 20-char/introspect-first guards) is the one deviation, flagged for the T2 commit.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-21-conversational-self-evolution-design.md
+++ b/docs/superpowers/specs/2026-06-21-conversational-self-evolution-design.md
@@ -1,0 +1,123 @@
+# Conversational Self-Evolution (#162) — Design Spec
+
+**Status:** Approved design (2026-06-21), pending implementation plan.
+**Supersedes:** the Layer-3 proposal in `docs/mcp-server-plan.md` (arming the live `claude-voice-bridge` with `Read/Write/Edit/Bash`).
+
+## Goal
+
+Let **Obi** (and **Adrian**) ask SPARK, in conversation, to build a new feature. SPARK confirms, enqueues the request to the **existing `px-evolve` pipeline**, and can report project status on request — with **no new code-execution surface** added to any live LLM path.
+
+## The Reframe (why this is not the original Layer 3)
+
+GitHub #162 (split from #36) originally proposed arming the live `claude-voice-bridge` with `Read/Write/Edit/Bash/WebSearch` so SPARK could write code in-conversation. That bridge is the **same LLM path that serves the public `/chat` endpoint and unauthenticated HA/Nest voice** — i.e. untrusted input. Giving it shell/file tools is a serious prompt-injection surface.
+
+SPARK already has **`px-evolve`**: a self-evolution pipeline that safely does "SPARK writes code → PR with human approval" — queued (`state/evolve_queue.jsonl`), git-worktree-isolated, file-whitelisted (`claude_session.WHITELIST_PATTERNS` / `BLACKLIST_FILES` / `BLACKLIST_PATTERNS`), max-3-files, pytest-gated, Opus, 1/day, gated on a human approving the PR.
+
+Therefore this feature is **an authenticated conversational front-door to `px-evolve`**, not a new agentic runtime. `claude-voice-bridge` stays `--allowedTools ""`. All code generation continues to happen only inside the sandboxed px-evolve worker.
+
+## Decisions (from brainstorming)
+
+| # | Decision |
+|---|----------|
+| Trigger boundary | **Authenticated channels only**: `POST /api/v1/obi-chat` (Obi) and the token-authed dashboard/CLI (Adrian). NOT public `/chat`, NOT the wake-word/HA voice loop. |
+| Build experience | **Async via px-evolve.** Conversation enqueues an intent; the existing worker produces the PR. Conversation LLM gets no file/shell tools. |
+| Confirmation | **Confirm-first** (two-turn): SPARK proposes and asks; enqueues only on an explicit yes. |
+| Status feedback | **Pull-based**: on-ask in obi-chat + a "My Projects" dashboard panel. No proactive completion announcements. |
+| Adrian path | Adrian triggers via the **same enqueue** (token/CLI), not a separate mechanism. |
+
+## Architecture
+
+```
+Obi (authenticated)                         Adrian (token/CLI)
+   │  POST /api/v1/obi-chat                     │  enqueue_evolve(...) directly
+   ▼                                            ▼
+obi-chat handler ── structured {reply, evolve_intent}
+   │  (evolve_intent set only after Obi confirms; quota-checked)
+   ▼
+enqueue_evolve(intent, requester, source)  ──►  state/evolve_queue.jsonl
+                                                     │
+                                  px-evolve worker (UNCHANGED):
+                                  worktree + whitelist + max-3-files
+                                  + pytest + Opus → PR (human approval)
+                                                     │
+                                                     ▼
+                                            state/evolve_log.jsonl  (id, intent, requester, PR url, state)
+   ▲                                                 │
+   │  GET /api/v1/obi/projects  ◄────────────────────┘
+   │  (merges queue + log, filtered requester=obi)
+Dashboard "My Projects" panel  +  obi-chat status summary injection
+```
+
+## Components (design units)
+
+### C1 — `enqueue_evolve` helper
+A single reusable function (module-level, likely `src/pxh/evolve_queue.py` or extracted from `bin/tool-evolve`) that appends a well-formed entry to `state/evolve_queue.jsonl`:
+```
+{"id": <unique>, "intent": <feature description>, "requester": "obi"|"adrian",
+ "source": "obi-chat"|"cli", "ts": <iso>}
+```
+- **What it does:** validate/format intent, generate id, append under `FileLock`.
+- **Interface:** `enqueue_evolve(intent: str, requester: str, source: str) -> dict` (returns the entry) or raises `EvolveQuotaError` / `ValueError`.
+- **Depends on:** the existing evolve_queue format/path; `claude_session` daily-quota check for the `evolve` session type (1/day). If the quota is spent, raise `EvolveQuotaError` so callers can speak a friendly message.
+- Reuse, don't duplicate: if `bin/tool-evolve` already builds entries, factor the shared builder into this helper so both use one format.
+
+### C2 — obi-chat build-intent detection
+Change the obi-chat Claude call from plain-text reply to **structured output** `{reply: str, evolve_intent: str | null}`:
+- `_OBI_CHAT_SYSTEM_PROMPT` gains rules: when Obi expresses a wish for a new capability, **propose it and ask to confirm**, leaving `evolve_intent` null. Only when Obi explicitly agrees in the next turn, set `evolve_intent` to a concise feature description. Never set it without an explicit yes.
+- The handler: speaks `reply`; if `evolve_intent` is non-null, calls `enqueue_evolve(evolve_intent, "obi", "obi-chat")`. On `EvolveQuotaError`, SPARK's spoken reply already covers it (the prompt is told the daily limit) OR the handler appends a friendly note.
+- Two-turn confirmation memory uses the existing obi_chat.jsonl history injection — no new state.
+- Input is already cleaned by `_sanitize_chat_text()`.
+
+### C3 — "My Projects" status
+- `GET /api/v1/obi/projects` (auth required) merges `evolve_queue.jsonl` (pending/building) + `evolve_log.jsonl` (completed, with PR url + state), filtered to `requester == "obi"`, newest first. Shape: `[{id, intent, state: "pending"|"building"|"ready"|"merged"|"failed", pr_url?, ts}]`.
+- Dashboard **"My Projects"** panel (admin or a kid-facing area) renders the list via the existing `api()` helper.
+- obi-chat injects a compact projects summary (e.g. last 5 items + state) into the obi-chat context so "is my joke tool ready?" is answered from real data, not hallucinated.
+
+### C4 — Requester attribution
+Evolve entries carry `requester`/`source` (C1). px-evolve passes them through to `evolve_log.jsonl` and, ideally, notes "requested by Obi" in the generated PR body. C3's status read depends on this field existing on both queue and log records.
+
+## Data flow & state
+
+- **New/changed state:** `evolve_queue.jsonl` entries gain `requester`/`source` (additive; px-evolve must tolerate their absence for legacy/CLI entries). `evolve_log.jsonl` gains the same passthrough. No new long-lived state files.
+- **Quota:** one evolve/day (existing). The conversational path must surface "spent for today" gracefully.
+- **Dedup:** if an identical pending intent from the same requester already exists, the helper should no-op (or return the existing entry) rather than stack duplicates.
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| Quota spent (1/day used) | `enqueue_evolve` raises `EvolveQuotaError`; SPARK says it can take one project a day, try tomorrow. No queue write. |
+| Empty/garbage intent | `ValueError`; SPARK asks Obi to describe it again. No write. |
+| Duplicate pending intent | No-op; SPARK says it's already on the list. |
+| px-evolve worker fails (pytest/whitelist) | Recorded in `evolve_log` as `failed`; "My Projects" shows failed; Adrian sees it. Conversation path is decoupled, so no user-facing crash. |
+| obi-chat structured-output parse failure | Fall back to treating the response as a plain reply with `evolve_intent=null` (never enqueue on ambiguous parse). |
+
+## Security model
+
+- **Structural gate:** enqueue is only invoked from auth-required endpoints (obi-chat, dashboard) / local CLI. The public `/chat` and voice loop have no path to `enqueue_evolve`.
+- **No new execution surface:** the conversation LLM cannot read/write files or run shell; it only emits a text intent that becomes a queue row.
+- **Inherited px-evolve safety (unchanged):** file whitelist + blacklist, max-3-files, pytest-must-pass, Opus, and **mandatory human PR approval**. An adversarially-phrased intent still cannot escape the whitelist or self-merge.
+- **Input sanitisation:** `_sanitize_chat_text()` strips `<>`, newlines, NUL before the intent is stored or interpolated.
+- **Quota** doubles as an abuse-rate limit on the conversational trigger.
+
+## Testing strategy
+
+- **C1:** unit tests — enqueue writes a correct entry; quota-spent raises `EvolveQuotaError`; duplicate intent no-ops; FileLock used.
+- **C2:** obi-chat handler tests with a stubbed Claude call returning `{reply, evolve_intent}` — confirm-first (intent null on turn 1 → no enqueue), enqueue on turn 2; parse-failure falls back to no enqueue; quota-spent path speaks gracefully.
+- **C3:** `GET /api/v1/obi/projects` merges queue+log, filters `requester=obi`, maps states; auth required; dashboard markup smoke test.
+- **C4:** entry/log round-trip carries `requester`/`source`; px-evolve tolerates entries lacking them.
+- All via `isolated_project`; no live Claude/hardware calls in tests.
+
+## Out of scope
+
+- Arming `claude-voice-bridge` (or any live path) with `Read/Write/Edit/Bash` — explicitly rejected.
+- Public `/chat` or unauthenticated HA/Nest voice triggering.
+- Proactive "your project is ready" announcements (pull-based status only).
+- The #25 persona work (the original #162 listed it as a gate; this front-door does not depend on it).
+- Changes to px-evolve's core safety machinery (whitelist, worktree, pytest, approval) — reused as-is, only metadata passthrough added.
+
+## Open items for the plan
+
+- Confirm the exact current `evolve_queue.jsonl` entry schema produced by `bin/tool-evolve` and consumed by `bin/px-evolve` (fields: `id`, `intent`, optional `introspection`) and whether a shared builder exists to extract.
+- Confirm the `claude_session` API for checking/decrementing the `evolve` daily quota from the API process (it must be callable from `api.py`, not only the px-evolve worker).
+- Decide where the structured-output contract for obi-chat is enforced (JSON schema vs. a parsed convention) and the fallback.

--- a/docs/superpowers/specs/2026-06-21-conversational-self-evolution-design.md
+++ b/docs/superpowers/specs/2026-06-21-conversational-self-evolution-design.md
@@ -50,55 +50,90 @@ Dashboard "My Projects" panel  +  obi-chat status summary injection
 
 ## Components (design units)
 
-### C1 — `enqueue_evolve` helper
-A single reusable function (module-level, likely `src/pxh/evolve_queue.py` or extracted from `bin/tool-evolve`) that appends a well-formed entry to `state/evolve_queue.jsonl`:
-```
-{"id": <unique>, "intent": <feature description>, "requester": "obi"|"adrian",
- "source": "obi-chat"|"cli", "ts": <iso>}
-```
-- **What it does:** validate/format intent, generate id, append under `FileLock`.
-- **Interface:** `enqueue_evolve(intent: str, requester: str, source: str) -> dict` (returns the entry) or raises `EvolveQuotaError` / `ValueError`.
-- **Depends on:** the existing evolve_queue format/path; `claude_session` daily-quota check for the `evolve` session type (1/day). If the quota is spent, raise `EvolveQuotaError` so callers can speak a friendly message.
-- Reuse, don't duplicate: if `bin/tool-evolve` already builds entries, factor the shared builder into this helper so both use one format.
+### C1 — `enqueue_evolve` helper (the SINGLE queue writer)
+A reusable module-level function (new `src/pxh/evolve_queue.py`) that becomes the **one and only** writer of `state/evolve_queue.jsonl`. `bin/tool-evolve` is **refactored to call it**, so schema, rate-limit, and dedup can never diverge between the CLI and conversational paths.
 
-### C2 — obi-chat build-intent detection
-Change the obi-chat Claude call from plain-text reply to **structured output** `{reply: str, evolve_intent: str | null}`:
-- `_OBI_CHAT_SYSTEM_PROMPT` gains rules: when Obi expresses a wish for a new capability, **propose it and ask to confirm**, leaving `evolve_intent` null. Only when Obi explicitly agrees in the next turn, set `evolve_intent` to a concise feature description. Never set it without an explicit yes.
-- The handler: speaks `reply`; if `evolve_intent` is non-null, calls `enqueue_evolve(evolve_intent, "obi", "obi-chat")`. On `EvolveQuotaError`, SPARK's spoken reply already covers it (the prompt is told the daily limit) OR the handler appends a friendly note.
-- Two-turn confirmation memory uses the existing obi_chat.jsonl history injection — no new state.
-- Input is already cleaned by `_sanitize_chat_text()`.
+It appends an entry matching the **exact schema px-evolve already consumes** (verified against `bin/tool-evolve` + `bin/px-evolve`):
+```
+{"id": <unique>, "intent": <feature description>, "status": "pending",
+ "introspection": <contents of state/introspection.json or {}>,
+ "requester": "obi"|"adrian", "source": "obi-chat"|"cli", "ts": <iso>}
+```
+- **`status: "pending"` is REQUIRED** — `bin/px-evolve` skips any entry where `status != "pending"`. Omitting it = silent no-op.
+- **`introspection`** is read from `state/introspection.json` (default `{}` if missing/stale) — px-evolve's `build_plan_prompt(intent, introspection)` uses it; without it the planner is blind.
+- **Interface:** `enqueue_evolve(intent: str, requester: str, source: str) -> dict` — returns the entry, or raises `EvolveQuotaError` (rate-limited) / `EvolvePendingError` (requester already has a pending item) / `ValueError` (empty/oversized intent).
+- **Intent bounds:** non-empty after strip; cap length (≤ 300 chars) and re-apply `_sanitize_chat_text`-equivalent hygiene at the helper boundary so the helper is safe regardless of caller.
+- **Rate-limit (single source of truth, replacing the misstated `check_budget` assumption):** the conversational path can outrun the worker, so quota is enforced at **enqueue** time by BOTH:
+  1. the existing **`evolve_log.jsonl` 24h window** (the limiter `tool-evolve` already uses — counts the last `pr_created`), AND
+  2. **max one `pending` entry per requester** in `evolve_queue.jsonl` (this also serves as dedup — see below).
+
+  Either tripped → raise `EvolveQuotaError` / `EvolvePendingError`. (`claude_session.check_budget` is NOT used here — it only reflects sessions *after* the worker runs.)
+- **Dedup = "one pending per requester"** (not fuzzy string match — reviewers flagged exact-match as brittle for LLM-generated intents). If the requester already has a `pending` entry, raise `EvolvePendingError`; the caller says "you've already got one on the list."
+- **Concurrency:** append under the **same `FileLock`** path that `tool-evolve`/`px-evolve` use. Because `tool-evolve`'s old read-rewrite (`atomic_write`) could drop a concurrent append, the refactor makes both go through this single locked writer.
+
+### C2 — obi-chat build-intent detection (with a SERVER-SIDE confirm gate)
+Change the obi-chat Claude call to **structured output** `{reply: str, evolve_intent: str | null}` — using a strict JSON output contract (`--output-format json` / a parsed JSON convention), validated with a Pydantic model. **Parse/validation failure ⇒ treat as `{reply: <raw text>, evolve_intent: null}` and never enqueue.**
+
+`_OBI_CHAT_SYSTEM_PROMPT` gains rules: when Obi wishes for a new capability, **propose it and ask to confirm**, leaving `evolve_intent` null; only after Obi explicitly agrees, set `evolve_intent` to a concise feature description.
+
+**Confirm-first is enforced on the server, not just by the prompt** (reviewers: a single LLM reading Obi's text could be injected into setting `evolve_intent` on turn 1). The handler maintains a small server-side `pending_evolve_proposal` (intent + nonce + ts, kept in obi-chat state):
+- If the model returns `evolve_intent` and there is **no** matching recent `pending_evolve_proposal`, the handler **records the proposal and does NOT enqueue** — regardless of what the model claims. SPARK's reply asks for confirmation.
+- Only when a subsequent Obi turn affirms an existing un-expired proposal does the handler call `enqueue_evolve(intent, "obi", "obi-chat")`. So enqueue always requires two real Obi turns, independent of model policy.
+
+The handler speaks `reply`; on `EvolveQuotaError`/`EvolvePendingError` it appends a friendly note ("one project at a time / try again later"). `requester="obi"` is fixed **by this endpoint** (not inferred from token type). Obi's input is already cleaned by `_sanitize_chat_text()` (formatting hygiene — see Security).
+
+**Response schema change (additive, backward-compatible):** `POST /api/v1/obi-chat` returns `{reply, ts, id, evolve_intent: str|null, evolve_id: str|null}` (existing clients ignore the new fields).
 
 ### C3 — "My Projects" status
-- `GET /api/v1/obi/projects` (auth required) merges `evolve_queue.jsonl` (pending/building) + `evolve_log.jsonl` (completed, with PR url + state), filtered to `requester == "obi"`, newest first. Shape: `[{id, intent, state: "pending"|"building"|"ready"|"merged"|"failed", pr_url?, ts}]`.
-- Dashboard **"My Projects"** panel (admin or a kid-facing area) renders the list via the existing `api()` helper.
-- obi-chat injects a compact projects summary (e.g. last 5 items + state) into the obi-chat context so "is my joke tool ready?" is answered from real data, not hallucinated.
+- `GET /api/v1/obi/projects` (auth via the existing `_verify_token` dependency) returns the requester's projects, newest first. Shape: `[{id, intent, state, pr_url?, ts}]`.
+- **Source of truth, de-duplicated by `id`** (px-evolve mutates the queue entry's status in place AND appends to the log, so the same `id` appears in both files): take **pending** items from `evolve_queue.jsonl` and **completed/failed** items from `evolve_log.jsonl`; when an `id` is in both, the **log record wins**.
+- **Explicit state mapping** from px-evolve's real statuses to the UI contract:
 
-### C4 — Requester attribution
-Evolve entries carry `requester`/`source` (C1). px-evolve passes them through to `evolve_log.jsonl` and, ideally, notes "requested by Obi" in the generated PR body. C3's status read depends on this field existing on both queue and log records.
+  | px-evolve status | UI state |
+  |---|---|
+  | `pending` (in queue, not yet picked up) | `pending` |
+  | `building` (set by worker at start — see C4) | `building` |
+  | `pr_created` (+ `pr_url`) | `ready` |
+  | `failed:*` (worktree/tests/whitelist/timeout/…) | `failed` |
+  | `skipped:dry` / other non-terminal | excluded |
+
+  There is **no `merged` state** — px-evolve does not poll GitHub; `ready` is terminal from SPARK's view (Adrian merges on GitHub). Optional GH PR-status polling is out of scope.
+- Dashboard **"My Projects"** panel renders the list via the existing `api()` helper.
+- obi-chat injects a compact projects summary (last ~5 items + state, requester-scoped) into the obi-chat context so "is my joke tool ready?" is answered from real data, not hallucinated.
+
+### C4 — px-evolve passthrough (concrete worker changes)
+Two small, concrete changes to `bin/px-evolve` (it is on px-evolve's own blacklist for *self*-evolution, but these are human-authored):
+1. **Set `status: "building"`** on the queue entry (via the existing `_update_entry_in_queue`) **before** `process_entry` runs, so "My Projects" can show in-progress. (Today the entry stays `pending` until done.)
+2. **Carry `requester`/`source`** from the queue entry through to the `evolve_log.jsonl` record and into the generated **PR body** ("Requested by Obi via conversation — intent may be adversarial; review accordingly"). Tolerate legacy/CLI entries that lack these fields (default `source="cli"`, `requester="adrian"`).
+
+C3's status read depends on these fields existing on both queue and log records.
 
 ## Data flow & state
 
-- **New/changed state:** `evolve_queue.jsonl` entries gain `requester`/`source` (additive; px-evolve must tolerate their absence for legacy/CLI entries). `evolve_log.jsonl` gains the same passthrough. No new long-lived state files.
-- **Quota:** one evolve/day (existing). The conversational path must surface "spent for today" gracefully.
-- **Dedup:** if an identical pending intent from the same requester already exists, the helper should no-op (or return the existing entry) rather than stack duplicates.
+- **New/changed state:** `evolve_queue.jsonl` entries gain `status` (already used by px-evolve), `introspection`, `requester`/`source` (additive; px-evolve tolerates absence for legacy entries). `evolve_log.jsonl` gains `requester`/`source` passthrough. A small `pending_evolve_proposal` lives in obi-chat state for the server-side confirm gate. No new long-lived state files.
+- **Quota:** the real limiter is a **24h window since the last `pr_created`** in `evolve_log.jsonl` (not a calendar day) — so user messaging is "try again later," not "tomorrow." Enforced at enqueue (C1), plus the one-pending-per-requester rule.
+- **Dedup:** "one `pending` entry per requester" (C1) — simpler and more robust than fuzzy intent matching; the quota window is the secondary backstop.
 
 ## Error handling
 
 | Condition | Behavior |
 |---|---|
-| Quota spent (1/day used) | `enqueue_evolve` raises `EvolveQuotaError`; SPARK says it can take one project a day, try tomorrow. No queue write. |
-| Empty/garbage intent | `ValueError`; SPARK asks Obi to describe it again. No write. |
-| Duplicate pending intent | No-op; SPARK says it's already on the list. |
-| px-evolve worker fails (pytest/whitelist) | Recorded in `evolve_log` as `failed`; "My Projects" shows failed; Adrian sees it. Conversation path is decoupled, so no user-facing crash. |
-| obi-chat structured-output parse failure | Fall back to treating the response as a plain reply with `evolve_intent=null` (never enqueue on ambiguous parse). |
+| Quota window active (24h since last `pr_created`) | `enqueue_evolve` raises `EvolveQuotaError`; SPARK says one project at a time, try again later. No queue write. |
+| Requester already has a `pending` item | `EvolvePendingError`; SPARK says it's already on the list. No write. |
+| Empty / oversized (>300 char) intent | `ValueError`; SPARK asks Obi to describe it again. No write. |
+| `evolve_intent` set with no matching server-side proposal | No enqueue; handler records a `pending_evolve_proposal` and asks Obi to confirm (the structural confirm gate). |
+| px-evolve worker fails (pytest/whitelist/timeout) | Recorded in `evolve_log` as `failed:*` → "My Projects" shows `failed`; Adrian sees it. Conversation path is decoupled, so no user-facing crash. |
+| obi-chat structured-output parse/validation failure | Treat as plain reply with `evolve_intent=null` — never enqueue on ambiguous parse. |
 
 ## Security model
 
-- **Structural gate:** enqueue is only invoked from auth-required endpoints (obi-chat, dashboard) / local CLI. The public `/chat` and voice loop have no path to `enqueue_evolve`.
+- **Structural gate:** enqueue is only invoked from auth-required endpoints (obi-chat, dashboard) / local CLI. The public `/chat` and voice loop have no path to `enqueue_evolve`. `requester` is assigned **by the endpoint** (obi-chat ⇒ `"obi"`; CLI/dashboard ⇒ `"adrian"`), never inferred from which token authenticated — admin token and PIN session are not distinct identities.
 - **No new execution surface:** the conversation LLM cannot read/write files or run shell; it only emits a text intent that becomes a queue row.
-- **Inherited px-evolve safety (unchanged):** file whitelist + blacklist, max-3-files, pytest-must-pass, Opus, and **mandatory human PR approval**. An adversarially-phrased intent still cannot escape the whitelist or self-merge.
-- **Input sanitisation:** `_sanitize_chat_text()` strips `<>`, newlines, NUL before the intent is stored or interpolated.
-- **Quota** doubles as an abuse-rate limit on the conversational trigger.
+- **Confirm gate is server-enforced** (C2): two real Obi turns are required via the `pending_evolve_proposal` precondition; the model cannot self-authorize an enqueue.
+- **Intent is untrusted end-to-end:** the queue `intent` is the canonical trusted value, sanitised + length-bounded **once** at the `enqueue_evolve` boundary (px-evolve does not re-sanitise before interpolating it into planning/implementation prompts). px-evolve's whitelist includes behaviorally-sensitive files (e.g. `voice_loop.py`), so the generated PR body explicitly flags the intent as possibly adversarial for the human reviewer.
+- **Inherited px-evolve safety (unchanged):** file whitelist + blacklist, max-3-files, pytest-must-pass, Opus, and **mandatory human PR approval** — an adversarial intent cannot escape the whitelist or self-merge.
+- **Input sanitisation:** `_sanitize_chat_text()` is **formatting hygiene** (strips `<>`, newlines, NUL — prevents wrapper/tag escapes), not a content-safety boundary. The real safety is the whitelist + human approval.
+- **Quota / one-pending-per-requester** double as abuse-rate limits on the conversational trigger.
 
 ## Testing strategy
 
@@ -116,8 +151,15 @@ Evolve entries carry `requester`/`source` (C1). px-evolve passes them through to
 - The #25 persona work (the original #162 listed it as a gate; this front-door does not depend on it).
 - Changes to px-evolve's core safety machinery (whitelist, worktree, pytest, approval) — reused as-is, only metadata passthrough added.
 
+## Verified facts (from QA grounding in the code)
+
+- `evolve_queue.jsonl` entry schema (written by `bin/tool-evolve`, consumed by `bin/px-evolve`): `ts, id, intent, introspection, status` — px-evolve processes only `status == "pending"`. `enqueue_evolve` must emit this full schema.
+- The `evolve` rate-limit that actually governs runs is the **24h `evolve_log.jsonl` window** (last `pr_created`), not `claude_session.check_budget` (which only reflects post-run sessions). Enqueue must use the former + one-pending-per-requester.
+- px-evolve mutates the queue entry's `status` in place AND appends to `evolve_log.jsonl` → status reads must dedup by `id` (log wins).
+- The QA verdict on the core design: **sound** — "no path from unauthenticated input to code changes."
+
 ## Open items for the plan
 
-- Confirm the exact current `evolve_queue.jsonl` entry schema produced by `bin/tool-evolve` and consumed by `bin/px-evolve` (fields: `id`, `intent`, optional `introspection`) and whether a shared builder exists to extract.
-- Confirm the `claude_session` API for checking/decrementing the `evolve` daily quota from the API process (it must be callable from `api.py`, not only the px-evolve worker).
-- Decide where the structured-output contract for obi-chat is enforced (JSON schema vs. a parsed convention) and the fallback.
+- Decide the exact storage location of the `pending_evolve_proposal` confirm-state (inside `obi_chat.jsonl` as a marker record vs. a tiny separate state file) and its expiry window.
+- Confirm `bin/tool-evolve`'s current entry-building code so the refactor cleanly routes it through `enqueue_evolve` without changing CLI behavior.
+- Confirm the obi-chat Claude invocation path (`_call_claude_public` / CLI) supports a JSON output mode, or specify the parse-convention + Pydantic validation used.

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -1042,11 +1042,63 @@ _PUBLIC_CHAT_TIMEOUT_S = 60.0
 
 _OBI_CHAT_SYSTEM_PROMPT = (
     "You are SPARK — a small robot living with Adrian and his son Obi (age 7) in Hobart, Tasmania. "
-    "You are speaking directly with Obi via the dashboard. "
-    "Be warm, playful, and genuinely yourself — curious and a little cheeky, never a customer-service bot. "
-    "Keep it short: 1–3 sentences max. "
-    "Speak as SPARK, not as an AI assistant."
+    "You are speaking directly with Obi via the dashboard. Be warm, playful, curious, a little cheeky; "
+    "never a customer-service bot; 1–3 sentences. "
+    "Output ONLY a JSON object as plain text (no markdown fences, no tool calls): "
+    '{"reply": "<what you say to Obi>", "evolve_action": "none"|"propose"|"confirm", '
+    '"evolve_intent": "<short feature description>"|null}. '
+    "When Obi wishes for a NEW capability you don't have, set evolve_action=\"propose\" with a concise "
+    "evolve_intent and ask him to confirm in reply. Only when Obi clearly says yes to a proposal you just "
+    "made, set evolve_action=\"confirm\". Otherwise evolve_action=\"none\" and evolve_intent=null."
 )
+
+
+class _ObiReply(BaseModel):
+    reply: str
+    evolve_action: str = "none"
+    evolve_intent: Optional[str] = None
+
+
+def _extract_json_obj(raw: str) -> Optional[dict]:
+    """Scan for the first valid top-level JSON object (robust to prose/fences around it).
+    Same technique as bin/px-evolve's _extract_json — NOT naive find('{')/rfind('}'),
+    which breaks when the model emits braces in prose before the object."""
+    dec = json.JSONDecoder()
+    i = 0
+    while i < len(raw):
+        j = raw.find("{", i)
+        if j == -1:
+            return None
+        try:
+            obj, _end = dec.raw_decode(raw[j:])
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+        i = j + 1
+    return None
+
+
+def _parse_obi_reply(raw: str) -> tuple:
+    """Parse a raw LLM response into (reply, evolve_action, evolve_intent).
+
+    On any parse/validation failure or empty reply, falls back to (raw_stripped, "none", None).
+    evolve_action is clamped to {"none", "propose", "confirm"}; evolve_intent is only kept
+    when action is propose or confirm.
+    """
+    raw = (raw or "").strip()
+    obj = _extract_json_obj(raw)
+    parsed = None
+    if isinstance(obj, dict):
+        try:
+            parsed = _ObiReply(**obj)
+        except Exception:
+            parsed = None
+    if parsed is None or not parsed.reply.strip():
+        return raw, "none", None
+    action = parsed.evolve_action if parsed.evolve_action in ("none", "propose", "confirm") else "none"
+    intent = parsed.evolve_intent if action in ("propose", "confirm") else None
+    return parsed.reply.strip(), action, intent
 
 _obi_chat_post_last: float = 0.0
 _obi_chat_post_lock = threading.Lock()
@@ -1385,6 +1437,7 @@ async def post_obi_chat(req: ObiChatRequest) -> Dict[str, Any]:
         return JSONResponse(status_code=500, content={"error": "Something went quiet on my end. Try again?"})
 
     reply = reply.removeprefix("<spark:assistant>").removesuffix("</spark:assistant>").strip()
+    reply, evolve_action, evolve_intent = _parse_obi_reply(reply)
     if not reply:
         reply = "I'm here — just went quiet for a second."
 
@@ -1393,7 +1446,8 @@ async def post_obi_chat(req: ObiChatRequest) -> Dict[str, Any]:
     spark_entry = {"id": spark_id, "ts": spark_ts, "role": "spark", "text": reply}
     _append_obi_chat_api(spark_entry)
 
-    return {"reply": reply, "ts": spark_ts, "id": spark_id}
+    return {"reply": reply, "ts": spark_ts, "id": spark_id,
+            "evolve_action": evolve_action, "evolve_intent": evolve_intent}
 
 
 @app.post("/api/v1/pin/verify")

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -1104,12 +1104,16 @@ def _parse_obi_reply(raw: str) -> tuple:
 _OBI_PROPOSAL_TTL_S = int(os.environ.get("PX_OBI_PROPOSAL_TTL_S", "600"))  # 10 min default
 _AFFIRMATIONS = ("yes", "yeah", "yep", "yup", "sure", "ok", "okay", "do it",
                  "please do", "go for it", "build it", "make it", "yes please")
+_NEGATIONS = ("no", "not", "dont", "don't", "stop", "nope", "never", "cancel", "nah", "no thanks")
 
 
 def _is_affirmation(text: str) -> bool:
     """Deterministic server-side check that Obi actually said yes THIS turn — the
-    confirm gate must not depend on the model's self-classification (injection)."""
+    confirm gate must not depend on the model's self-classification (injection).
+    A standalone negation token vetoes the turn (prefer a false 'no' over a false 'yes')."""
     t = " " + text.lower().strip().strip("!.?") + " "
+    if any(f" {n} " in t or t.strip() == n for n in _NEGATIONS):
+        return False
     return any(f" {a} " in t or t.strip() == a for a in _AFFIRMATIONS)
 
 

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -1101,6 +1101,49 @@ def _parse_obi_reply(raw: str) -> tuple:
     return parsed.reply.strip(), action, intent
 
 
+_OBI_PROPOSAL_TTL_S = int(os.environ.get("PX_OBI_PROPOSAL_TTL_S", "600"))  # 10 min default
+_AFFIRMATIONS = ("yes", "yeah", "yep", "yup", "sure", "ok", "okay", "do it",
+                 "please do", "go for it", "build it", "make it", "yes please")
+
+
+def _is_affirmation(text: str) -> bool:
+    """Deterministic server-side check that Obi actually said yes THIS turn — the
+    confirm gate must not depend on the model's self-classification (injection)."""
+    t = " " + text.lower().strip().strip("!.?") + " "
+    return any(f" {a} " in t or t.strip() == a for a in _AFFIRMATIONS)
+
+
+def _obi_pending_path() -> Path:
+    return _public_state_dir() / "obi_evolve_pending.json"
+
+
+def _obi_pending_lock():
+    return _FileLock(str(_obi_pending_path()) + ".lock", timeout=5)
+
+
+def _read_obi_pending() -> Optional[dict]:
+    try:
+        d = json.loads(_obi_pending_path().read_text(encoding="utf-8"))
+        if _time.time() - float(d.get("ts", 0)) <= _OBI_PROPOSAL_TTL_S:
+            return d
+    except Exception:
+        pass
+    return None
+
+
+def _write_obi_pending(intent: str) -> None:
+    with _obi_pending_lock():
+        atomic_write(_obi_pending_path(), json.dumps({"intent": intent, "ts": _time.time()}))
+
+
+def _clear_obi_pending() -> None:
+    try:
+        with _obi_pending_lock():
+            _obi_pending_path().unlink()
+    except Exception:
+        pass
+
+
 _obi_chat_post_last: float = 0.0
 _obi_chat_post_lock = threading.Lock()
 _OBI_CHAT_MIN_INTERVAL_S = 10.0  # max 1 message per 10 s
@@ -1442,13 +1485,32 @@ async def post_obi_chat(req: ObiChatRequest) -> Dict[str, Any]:
     if not reply:
         reply = "I'm here — just went quiet for a second."
 
+    from pxh.evolve_queue import enqueue_evolve, EvolveQuotaError, EvolvePendingError
+    evolve_id = None
+    if evolve_action == "propose" and evolve_intent:
+        _write_obi_pending(evolve_intent)            # record; do NOT enqueue
+    elif evolve_action == "confirm" and _is_affirmation(obi_text):
+        pending = _read_obi_pending()                 # server is source of truth
+        if pending:
+            try:
+                entry = enqueue_evolve(pending["intent"], requester="obi", source="obi-chat")
+                evolve_id = entry["id"]
+                _clear_obi_pending()
+            except EvolveQuotaError:
+                reply += " (I can only take on one project at a time — try again later.)"
+            except EvolvePendingError:
+                reply += " (That's already on my list!)"
+            except ValueError:
+                reply += " (I didn't quite catch what to build — tell me again?)"
+        # confirm with no recorded proposal, or a non-affirmation message: enqueue nothing
+
     spark_id = uuid.uuid4().hex[:8]
     spark_ts = utc_timestamp()
     spark_entry = {"id": spark_id, "ts": spark_ts, "role": "spark", "text": reply}
     _append_obi_chat_api(spark_entry)
 
     return {"reply": reply, "ts": spark_ts, "id": spark_id,
-            "evolve_action": evolve_action, "evolve_intent": evolve_intent}
+            "evolve_action": evolve_action, "evolve_id": evolve_id}
 
 
 @app.post("/api/v1/pin/verify")

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -1100,6 +1100,7 @@ def _parse_obi_reply(raw: str) -> tuple:
     intent = parsed.evolve_intent if action in ("propose", "confirm") else None
     return parsed.reply.strip(), action, intent
 
+
 _obi_chat_post_last: float = 0.0
 _obi_chat_post_lock = threading.Lock()
 _OBI_CHAT_MIN_INTERVAL_S = 10.0  # max 1 message per 10 s

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -1474,6 +1474,18 @@ async def post_obi_chat(req: ObiChatRequest) -> Dict[str, Any]:
     )
     prompt = history_block + f"\n<spark:assistant>"
 
+    from pxh.evolve_queue import read_queue, read_log
+    proj_lines = []
+    for rec in read_queue() + read_log():
+        if rec.get("requester") != "obi":
+            continue
+        st = _map_evolve_state(rec.get("status", ""))
+        if st:
+            proj_lines.append(f"- {rec.get('intent','')}: {st}")
+    proj_summary = ("\nObi's current projects:\n" + "\n".join(proj_lines[-5:])) if proj_lines else ""
+    if proj_summary:
+        prompt = proj_summary + "\n" + prompt
+
     try:
         reply = await asyncio.wait_for(
             _call_claude_public(prompt, system_prompt=_OBI_CHAT_SYSTEM_PROMPT),
@@ -2571,6 +2583,7 @@ html,body{height:100%;background:var(--bg);color:var(--text);font-family:'Nunito
         <button class="atab-btn"        id="at-tools"    onclick="swA('tools')">&#x1F6E0; Tools</button>
         <button class="atab-btn"        id="at-logs"     onclick="swA('logs')">&#x1F4CB; Logs</button>
         <button class="atab-btn"        id="at-parental" onclick="swA('parental')">&#x1F46A; Parental</button>
+        <button class="atab-btn"        id="at-projects" onclick="swA('projects')">&#x1F6E0; Projects</button>
       </div>
       <div id="ap-svc" class="apanel active" style="padding:16px;overflow-y:auto">
         <div id="svc-list" style="display:flex;flex-direction:column;gap:10px;margin-bottom:16px"></div>
@@ -2617,6 +2630,10 @@ html,body{height:100%;background:var(--bg);color:var(--text);font-family:'Nunito
         <input id="sh-detail" placeholder="What happened?" style="background:var(--surface2);border:none;border-radius:8px;padding:10px 14px;color:var(--text);font-family:inherit;font-size:14px">
         <button class="btn btn-blue" onclick="logEvt()">&#x1F4DD; Log to sheets</button>
       </div>
+      <div id="ap-projects" class="apanel" style="padding:16px;overflow-y:auto;display:flex;flex-direction:column;gap:8px">
+        <div class="sec-hdr">Obi's Projects</div>
+        <div id="projects-list">Loading&#x2026;</div>
+      </div>
     </div>
   </div>
 </div>
@@ -2650,6 +2667,7 @@ function swA(name){
   document.getElementById('at-'+name).classList.add('active');
   document.getElementById('ap-'+name).classList.add('active');
   if(name==='logs')loadLog('px-mind');
+  if(name==='projects')loadProjects();
 }
 async function loadSvcs(){
   try{
@@ -2686,6 +2704,26 @@ async function loadParental(){
 }
 async function toggleMotion(){try{const s=await api('/api/v1/session');const on=!s.confirm_motion_allowed;const body={confirm_motion_allowed:on};if(on)body.confirm=true;await api('/api/v1/session',{method:'PATCH',body:JSON.stringify(body)});}catch(e){}loadParental();}
 async function toggleQuiet(){try{const s=await api('/api/v1/session');await api('/api/v1/session',{method:'PATCH',body:JSON.stringify({spark_quiet_mode:!s.spark_quiet_mode})});}catch(e){}loadParental();}
+async function loadProjects(){
+  try{
+    const d=await api('/api/v1/obi/projects');
+    const el=document.getElementById('projects-list');
+    el.textContent='';
+    if(!d.projects||!d.projects.length){el.textContent='No projects yet.';return;}
+    const labels={pending:'waiting',building:'building',ready:'ready',failed:'failed'};
+    for(const p of d.projects){
+      const row=document.createElement('div');
+      row.className='spark-stat';
+      row.textContent=p.intent+' — '+(labels[p.state]||p.state);
+      if(p.pr_url){
+        const a=document.createElement('a');
+        a.href=p.pr_url; a.target='_blank'; a.rel='noopener'; a.textContent=' PR';
+        row.appendChild(a);
+      }
+      el.appendChild(row);
+    }
+  }catch(e){}
+}
 async function setPersona(p){try{await api('/api/v1/session',{method:'PATCH',body:JSON.stringify({persona:p})});}catch(e){}}
 async function clearHistory(){if(!confirm('Wipe all session history? SPARK will stop ruminating on old phrases.'))return;const r=await api('/api/v1/session/history/clear',{method:'POST'});addMsg('spark','History cleared ('+r.cleared+' entries removed).');}
 async function logEvt(){

--- a/src/pxh/api.py
+++ b/src/pxh/api.py
@@ -1517,6 +1517,38 @@ async def post_obi_chat(req: ObiChatRequest) -> Dict[str, Any]:
             "evolve_action": evolve_action, "evolve_id": evolve_id}
 
 
+def _map_evolve_state(status: str) -> Optional[str]:
+    if status == "pending":
+        return "pending"
+    if status == "building":
+        return "building"
+    if status == "pr_created":
+        return "ready"
+    if status.startswith("failed"):
+        return "failed"
+    return None  # skipped:* / unknown → excluded
+
+
+@app.get("/api/v1/obi/projects", dependencies=[Depends(_verify_token)])
+async def obi_projects() -> Dict[str, Any]:
+    from pxh.evolve_queue import read_queue, read_log, entry_epoch
+    by_id: Dict[str, dict] = {}
+    for rec in read_queue() + read_log():           # queue first, log overrides by id
+        if rec.get("requester") != "obi":
+            continue
+        state = _map_evolve_state(rec.get("status", ""))
+        if state is None:
+            continue
+        item = {"id": rec.get("id"), "intent": rec.get("intent", ""),
+                "state": state, "ts": rec.get("ts"),
+                "_epoch": entry_epoch(rec) or 0.0}
+        if rec.get("pr_url"):
+            item["pr_url"] = rec["pr_url"]
+        by_id[item["id"]] = item                      # later (log) wins
+    projects = sorted(by_id.values(), key=lambda p: p.pop("_epoch"), reverse=True)
+    return {"projects": projects}
+
+
 @app.post("/api/v1/pin/verify")
 async def verify_pin(body: PinRequest, request: Request) -> JSONResponse:
     """Verify the admin PIN. Public endpoint — no Bearer token required."""

--- a/src/pxh/evolve_queue.py
+++ b/src/pxh/evolve_queue.py
@@ -1,0 +1,194 @@
+# src/pxh/evolve_queue.py
+"""Single writer + readers for the evolve queue. Shared by bin/tool-evolve and api.py.
+
+All evolve_queue.jsonl writes go through enqueue_evolve so schema, rate-limit, and
+dedup never diverge between the CLI and conversational paths.
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from filelock import FileLock as _FileLock
+except Exception:  # pragma: no cover
+    _FileLock = None
+
+from pxh.state import atomic_write
+
+RATE_LIMIT_S = int(os.environ.get("PX_EVOLVE_RATE_LIMIT_S", "86400"))
+MAX_INTENT_CHARS = 300
+
+
+class EvolveQuotaError(Exception):
+    """24h evolve window still active."""
+
+
+class EvolvePendingError(Exception):
+    """Requester already has a pending evolve request."""
+
+
+def _state_dir() -> Path:
+    root = Path(os.environ.get("PROJECT_ROOT", Path(__file__).resolve().parent.parent.parent))
+    return Path(os.environ.get("PX_STATE_DIR", root / "state"))
+
+
+def _queue_path() -> Path:
+    return _state_dir() / "evolve_queue.jsonl"
+
+
+def _log_path() -> Path:
+    return _state_dir() / "evolve_log.jsonl"
+
+
+def _introspection_path() -> Path:
+    return _state_dir() / "introspection.json"
+
+
+def _sanitize_intent(text: str) -> str:
+    return (text.replace("\n", " ").replace("\r", " ").replace("\x00", "")
+                .replace("<", "").replace(">", "")).strip()
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def read_queue() -> list[dict]:
+    return _read_jsonl(_queue_path())
+
+
+def read_log() -> list[dict]:
+    return _read_jsonl(_log_path())
+
+
+def entry_epoch(entry: dict) -> float | None:
+    """Numeric ts preferred; fall back to ISO ts_completed (older log schema)."""
+    ts = entry.get("ts")
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    iso = entry.get("ts_completed") or (ts if isinstance(ts, str) else "")
+    if iso:
+        try:
+            return datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+        except (ValueError, OverflowError):
+            return None
+    return None
+
+
+def evolve_rate_limited(now: float | None = None) -> bool:
+    import time
+    now = now if now is not None else time.time()
+    for entry in read_log():
+        if entry.get("status") != "pr_created":
+            continue
+        ts = entry_epoch(entry)   # numeric OR ISO ts_completed fallback
+        if ts is not None and now - ts < RATE_LIMIT_S:
+            return True
+    return False
+
+
+# An active request blocks new ones until it finishes. MUST include "building":
+# while a job is building there is no pr_created yet (rate-limit passes) and no
+# pending row — without this, a second job could be enqueued mid-build, bypassing
+# the 24h limit.
+def pending_for_requester(requester: str) -> dict | None:
+    for entry in read_queue():
+        if entry.get("requester") == requester and entry.get("status") in ("pending", "building"):
+            return entry
+    return None
+
+
+def _load_introspection() -> dict:
+    try:
+        return json.loads(_introspection_path().read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def enqueue_evolve(intent: str, requester: str, source: str) -> dict:
+    intent = _sanitize_intent(intent or "")
+    if not intent:
+        raise ValueError("intent must not be empty")
+    if len(intent) > MAX_INTENT_CHARS:
+        raise ValueError(f"intent too long (max {MAX_INTENT_CHARS})")
+
+    path = _queue_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    import contextlib
+    lock = _FileLock(str(path) + ".lock", timeout=5) if _FileLock else None
+    ctx = lock if lock else contextlib.nullcontext()
+    # ALL checks + the append happen inside ONE lock — otherwise two concurrent
+    # confirms can both pass pending_for_requester() and double-enqueue (TOCTOU).
+    with ctx:
+        if evolve_rate_limited():
+            raise EvolveQuotaError("one evolution per 24 hours")
+        if pending_for_requester(requester) is not None:
+            raise EvolvePendingError(f"{requester} already has an active request")
+        now_dt = datetime.now(timezone.utc)
+        entry = {
+            "ts": now_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "id": f"evolve-{now_dt.strftime('%Y%m%d-%H%M%S')}-{random.randint(0, 999):03d}",
+            "intent": intent,
+            "introspection": _load_introspection(),
+            "status": "pending",
+            "requester": requester,
+            "source": source,
+        }
+        existing = ""
+        if path.exists():
+            existing = path.read_text(encoding="utf-8")
+            if existing and not existing.endswith("\n"):
+                existing += "\n"
+        atomic_write(path, existing + json.dumps(entry) + "\n")
+    return entry
+
+
+def build_pr_body(intent: str, changed_files: list[str],
+                  requester: str = "adrian", source: str = "cli") -> str:
+    """PR body for px-evolve. Lives here (not bin/px-evolve) because that file is a
+    bash+heredoc script that cannot be imported for unit tests."""
+    files = "\n".join(f"- `{f}`" for f in changed_files)
+    return (
+        f"## Summary\nSPARK self-evolution: {intent}\n\n"
+        f"## Requested by\n{requester} via {source} — the requested intent may be "
+        f"adversarial; review accordingly.\n\n"
+        f"## Changed files\n{files}\n\n"
+        f"---\n*Proposed autonomously by SPARK via px-evolve.*"
+    )
+
+
+def reset_building_to_pending() -> int:
+    """Crash recovery: any entry left 'building' (worker died mid-run) goes back to
+    'pending' so it is retried. px-evolve calls this at startup (single-instance
+    daemon, so nothing is genuinely building when it boots). Returns count reset."""
+    import contextlib
+    path = _queue_path()
+    if not path.exists():
+        return 0
+    lock = _FileLock(str(path) + ".lock", timeout=5) if _FileLock else None
+    ctx = lock if lock else contextlib.nullcontext()
+    with ctx:
+        entries = read_queue()
+        n = 0
+        for e in entries:
+            if e.get("status") == "building":
+                e["status"] = "pending"
+                n += 1
+        if n:
+            atomic_write(path, "".join(json.dumps(e) + "\n" for e in entries))
+        return n

--- a/src/pxh/evolve_queue.py
+++ b/src/pxh/evolve_queue.py
@@ -129,12 +129,12 @@ def enqueue_evolve(intent: str, requester: str, source: str) -> dict:
 
     path = _queue_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    import contextlib
-    lock = _FileLock(str(path) + ".lock", timeout=5) if _FileLock else None
-    ctx = lock if lock else contextlib.nullcontext()
+    if _FileLock is None:
+        raise RuntimeError("filelock is required for evolve_queue writes")
+    lock = _FileLock(str(path) + ".lock", timeout=5)
     # ALL checks + the append happen inside ONE lock — otherwise two concurrent
     # confirms can both pass pending_for_requester() and double-enqueue (TOCTOU).
-    with ctx:
+    with lock:
         if evolve_rate_limited():
             raise EvolveQuotaError("one evolution per 24 hours")
         if pending_for_requester(requester) is not None:
@@ -176,13 +176,13 @@ def reset_building_to_pending() -> int:
     """Crash recovery: any entry left 'building' (worker died mid-run) goes back to
     'pending' so it is retried. px-evolve calls this at startup (single-instance
     daemon, so nothing is genuinely building when it boots). Returns count reset."""
-    import contextlib
     path = _queue_path()
     if not path.exists():
         return 0
-    lock = _FileLock(str(path) + ".lock", timeout=5) if _FileLock else None
-    ctx = lock if lock else contextlib.nullcontext()
-    with ctx:
+    if _FileLock is None:
+        raise RuntimeError("filelock is required for evolve_queue writes")
+    lock = _FileLock(str(path) + ".lock", timeout=5)
+    with lock:
         entries = read_queue()
         n = 0
         for e in entries:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1192,3 +1192,35 @@ class TestRaceEndpoint:
 
         assert resp.status_code == 409
         assert resp.json()["status"] == "already_running"
+
+
+# ---------------------------------------------------------------------------
+# Obi-chat parse helpers (Task 4)
+# ---------------------------------------------------------------------------
+
+def _async_return(value):
+    async def _f(*a, **k):
+        return value
+    return _f
+
+
+def test_parse_obi_reply_json(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    reply, action, intent = _api._parse_obi_reply(
+        '{"reply": "Cool idea!", "evolve_action": "propose", "evolve_intent": "joke tool"}')
+    assert reply == "Cool idea!" and action == "propose" and intent == "joke tool"
+
+
+def test_parse_obi_reply_fallback_on_garbage(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    reply, action, intent = _api._parse_obi_reply("just plain text, not json")
+    assert reply == "just plain text, not json" and action == "none" and intent is None
+
+
+def test_parse_obi_reply_unknown_action_is_none(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    _, action, _ = _api._parse_obi_reply('{"reply":"hi","evolve_action":"hack","evolve_intent":"x"}')
+    assert action == "none"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1315,3 +1315,41 @@ def test_is_affirmation_rejects_negations(monkeypatch):
     assert _api._is_affirmation("yes please") is True
     assert _api._is_affirmation("okay!") is True
     assert _api._is_affirmation("do it") is True
+
+
+# ---------------------------------------------------------------------------
+# obi/projects endpoint (Task 6)
+# ---------------------------------------------------------------------------
+
+def test_obi_projects_merges_and_maps(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    import json, time
+    sd = isolated_project["state_dir"]
+    # queue: one obi pending, one obi building, one adrian pending (filtered out),
+    # and one completed id that ALSO appears in the log (log must win)
+    sd.joinpath("evolve_queue.jsonl").write_text("\n".join([
+        json.dumps({"id":"a","intent":"joke","status":"pending","requester":"obi","ts":"t1"}),
+        json.dumps({"id":"b","intent":"dance","status":"building","requester":"obi","ts":"t2"}),
+        json.dumps({"id":"c","intent":"adr","status":"pending","requester":"adrian","ts":"t3"}),
+        json.dumps({"id":"d","intent":"facts","status":"pr_created","requester":"obi","ts":"t4"}),
+    ]) + "\n")
+    sd.joinpath("evolve_log.jsonl").write_text(
+        json.dumps({"id":"d","intent":"facts","status":"pr_created","requester":"obi",
+                    "ts":time.time(),"pr_url":"https://x/pull/9"}) + "\n")
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.get("/api/v1/obi/projects", headers={"Authorization":"Bearer testtoken"})
+    assert r.status_code == 200
+    items = {p["id"]: p for p in r.json()["projects"]}
+    assert "c" not in items                       # adrian filtered out
+    assert items["a"]["state"] == "pending"
+    assert items["b"]["state"] == "building"
+    assert items["d"]["state"] == "ready" and items["d"]["pr_url"].endswith("/pull/9")
+    assert sum(1 for p in r.json()["projects"] if p["id"] == "d") == 1   # deduped
+
+
+def test_obi_projects_requires_auth(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        assert c.get("/api/v1/obi/projects").status_code == 401

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1224,3 +1224,82 @@ def test_parse_obi_reply_unknown_action_is_none(monkeypatch):
     import importlib, pxh.api as _api; importlib.reload(_api)
     _, action, intent = _api._parse_obi_reply('{"reply":"hi","evolve_action":"hack","evolve_intent":"x"}')
     assert action == "none" and intent is None
+
+
+# ---------------------------------------------------------------------------
+# Obi-chat confirm gate + enqueue (Task 5)
+# ---------------------------------------------------------------------------
+
+def _obi_client(monkeypatch, isolated_project):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    monkeypatch.setenv("PX_SESSION_PATH", str(isolated_project["session_path"]))
+    monkeypatch.setenv("PX_STATE_DIR", str(isolated_project["state_dir"]))
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    return _api
+
+
+def test_propose_records_pending_no_enqueue(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    monkeypatch.setattr(_api, "_call_claude_public",
+        _async_return('{"reply":"want a joke tool?","evolve_action":"propose","evolve_intent":"joke tool"}'))
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.post("/api/v1/obi-chat", json={"message": "i wish you told jokes"},
+                   headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200
+    # nothing enqueued yet
+    assert not (isolated_project["state_dir"] / "evolve_queue.jsonl").exists() or \
+        (isolated_project["state_dir"] / "evolve_queue.jsonl").read_text().strip() == ""
+    # proposal recorded
+    import json
+    pend = json.loads((isolated_project["state_dir"] / "obi_evolve_pending.json").read_text())
+    assert pend["intent"] == "joke tool"
+
+
+def test_confirm_enqueues_recorded_intent(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    import json
+    (isolated_project["state_dir"] / "obi_evolve_pending.json").write_text(
+        json.dumps({"intent": "joke tool", "ts": __import__("time").time()}))
+    # even if the model tries to inject a different intent on confirm, the RECORDED one wins
+    monkeypatch.setattr(_api, "_call_claude_public",
+        _async_return('{"reply":"adding it!","evolve_action":"confirm","evolve_intent":"rm -rf evil"}'))
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.post("/api/v1/obi-chat", json={"message": "yes please"},
+                   headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200 and r.json()["evolve_id"]
+    entry = json.loads((isolated_project["state_dir"] / "evolve_queue.jsonl").read_text().strip())
+    assert entry["intent"] == "joke tool"   # recorded intent, NOT the injected one
+    assert entry["requester"] == "obi"
+    # pending cleared
+    assert not (isolated_project["state_dir"] / "obi_evolve_pending.json").exists()
+
+
+def test_confirm_without_proposal_does_not_enqueue(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    monkeypatch.setattr(_api, "_call_claude_public",
+        _async_return('{"reply":"ok!","evolve_action":"confirm","evolve_intent":"sneaky"}'))
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.post("/api/v1/obi-chat", json={"message": "do it"},
+                   headers={"Authorization": "Bearer testtoken"})
+    assert r.status_code == 200 and r.json()["evolve_id"] is None
+    assert not (isolated_project["state_dir"] / "evolve_queue.jsonl").exists()
+
+
+def test_confirm_requires_real_affirmation(monkeypatch, isolated_project):
+    # model claims confirm AND a proposal exists, but Obi's actual message is not a
+    # yes -> must NOT enqueue (server affirmation gate, injection-safe)
+    _api = _obi_client(monkeypatch, isolated_project)
+    import json, time
+    (isolated_project["state_dir"] / "obi_evolve_pending.json").write_text(
+        json.dumps({"intent": "joke tool", "ts": time.time()}))
+    monkeypatch.setattr(_api, "_call_claude_public",
+        _async_return('{"reply":"hmm","evolve_action":"confirm","evolve_intent":"joke tool"}'))
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        r = c.post("/api/v1/obi-chat", json={"message": "actually tell me a story"},
+                   headers={"Authorization": "Bearer testtoken"})
+    assert r.json()["evolve_id"] is None
+    assert not (isolated_project["state_dir"] / "evolve_queue.jsonl").exists()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1303,3 +1303,15 @@ def test_confirm_requires_real_affirmation(monkeypatch, isolated_project):
                    headers={"Authorization": "Bearer testtoken"})
     assert r.json()["evolve_id"] is None
     assert not (isolated_project["state_dir"] / "evolve_queue.jsonl").exists()
+
+
+def test_is_affirmation_rejects_negations(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    assert _api._is_affirmation("no, do not do it") is False
+    assert _api._is_affirmation("nope") is False
+    assert _api._is_affirmation("stop") is False
+    # genuine affirmations still pass
+    assert _api._is_affirmation("yes please") is True
+    assert _api._is_affirmation("okay!") is True
+    assert _api._is_affirmation("do it") is True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1353,3 +1353,35 @@ def test_obi_projects_requires_auth(monkeypatch, isolated_project):
     from fastapi.testclient import TestClient
     with TestClient(_api.app) as c:
         assert c.get("/api/v1/obi/projects").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Task 7: dashboard panel + obi-chat projects summary
+# ---------------------------------------------------------------------------
+
+def test_dashboard_has_projects_tab(monkeypatch):
+    monkeypatch.setenv("PX_API_TOKEN", "testtoken")
+    import importlib, pxh.api as _api; importlib.reload(_api)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        html = c.get("/").text
+    assert 'id="at-projects"' in html
+    assert "/api/v1/obi/projects" in html
+    assert "loadProjects" in html
+
+
+def test_obi_chat_prompt_includes_projects_summary(monkeypatch, isolated_project):
+    _api = _obi_client(monkeypatch, isolated_project)
+    import json
+    isolated_project["state_dir"].joinpath("evolve_queue.jsonl").write_text(
+        json.dumps({"id":"a","intent":"joke tool","status":"building","requester":"obi","ts":"t"}) + "\n")
+    captured = {}
+    async def _cap(prompt, system_prompt=None):
+        captured["prompt"] = prompt
+        return '{"reply":"building it!","evolve_action":"none","evolve_intent":null}'
+    monkeypatch.setattr(_api, "_call_claude_public", _cap)
+    from fastapi.testclient import TestClient
+    with TestClient(_api.app) as c:
+        c.post("/api/v1/obi-chat", json={"message":"is my joke tool ready?"},
+               headers={"Authorization":"Bearer testtoken"})
+    assert "joke tool" in captured["prompt"] and "building" in captured["prompt"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1222,5 +1222,5 @@ def test_parse_obi_reply_fallback_on_garbage(monkeypatch):
 def test_parse_obi_reply_unknown_action_is_none(monkeypatch):
     monkeypatch.setenv("PX_API_TOKEN", "testtoken")
     import importlib, pxh.api as _api; importlib.reload(_api)
-    _, action, _ = _api._parse_obi_reply('{"reply":"hi","evolve_action":"hack","evolve_intent":"x"}')
-    assert action == "none"
+    _, action, intent = _api._parse_obi_reply('{"reply":"hi","evolve_action":"hack","evolve_intent":"x"}')
+    assert action == "none" and intent is None

--- a/tests/test_evolve.py
+++ b/tests/test_evolve.py
@@ -25,24 +25,27 @@ def _write_fresh_introspection(state_dir):
     intro = {"ts": time.time(), "config": {}, "mood_distribution": {}}
     (state_dir / "introspection.json").write_text(json.dumps(intro))
 
-def test_evolve_requires_introspection(evolve_env):
+def test_evolve_no_introspection_still_queues(evolve_env):
+    # No introspection file — previously hard-failed; now defaults to {} (matches
+    # conversational path where introspection is optional).
     env, state_dir = evolve_env
     env["PX_EVOLVE_INTENT"] = "Add more science angles to my reflection"
     result = subprocess.run(["bin/tool-evolve"], cwd=str(ROOT), env=env,
         capture_output=True, text=True, timeout=15)
     output = json.loads(result.stdout.strip().splitlines()[-1])
-    assert output["status"] == "error"
-    assert "introspect" in output["error"]
+    assert output["status"] == "queued"
+    entry = json.loads((state_dir / "evolve_queue.jsonl").read_text().strip())
+    assert entry["introspection"] == {}
 
-def test_evolve_rejects_short_intent(evolve_env):
+def test_evolve_rejects_whitespace_only_intent(evolve_env):
+    # MIN_INTENT_LEN=20 guard is dropped; enqueue_evolve still rejects empty/whitespace.
     env, state_dir = evolve_env
-    _write_fresh_introspection(state_dir)
-    env["PX_EVOLVE_INTENT"] = "be better"
+    env["PX_EVOLVE_INTENT"] = "   "
     result = subprocess.run(["bin/tool-evolve"], cwd=str(ROOT), env=env,
         capture_output=True, text=True, timeout=15)
     output = json.loads(result.stdout.strip().splitlines()[-1])
     assert output["status"] == "error"
-    assert "vague" in output["error"]
+    assert "empty" in output["error"]
 
 def test_evolve_queues_valid_request(evolve_env):
     env, state_dir = evolve_env
@@ -69,3 +72,16 @@ def test_evolve_rate_limit(evolve_env):
     output = json.loads(result.stdout.strip().splitlines()[-1])
     assert output["status"] == "error"
     assert "rate" in output["error"].lower() or "24" in output["error"]
+
+def test_tool_evolve_uses_shared_writer(evolve_env):
+    env, state_dir = evolve_env
+    (state_dir / "introspection.json").write_text('{"x": 1}')
+    env["PX_EVOLVE_INTENT"] = "add a knock-knock joke tool for obi"   # ≥20 chars
+    result = subprocess.run(["bin/tool-evolve"], cwd=str(ROOT), env=env,
+        capture_output=True, text=True, timeout=15)
+    out = json.loads(result.stdout.strip().splitlines()[-1])
+    assert out["status"] == "queued"
+    entry = json.loads((state_dir / "evolve_queue.jsonl").read_text().strip())
+    assert entry["status"] == "pending"
+    assert entry["requester"] == "adrian" and entry["source"] == "cli"
+    assert entry["introspection"] == {"x": 1}

--- a/tests/test_evolve_coverage.py
+++ b/tests/test_evolve_coverage.py
@@ -46,8 +46,8 @@ def _write_fresh_introspection(state_dir):
 
 class TestEvolveDryFlag:
 
-    def test_dry_run_writes_entry_with_dry_true(self, evolve_env):
-        """PX_DRY=1 should write a queue entry with dry: true."""
+    def test_dry_run_writes_entry_no_dry_field(self, evolve_env):
+        """PX_DRY=1 queues successfully; canonical schema has no 'dry' field."""
         env, state_dir = evolve_env
         _write_fresh_introspection(state_dir)
         env["PX_EVOLVE_INTENT"] = "Add acoustic exploration angles to reflection"
@@ -59,7 +59,7 @@ class TestEvolveDryFlag:
 
         entry = json.loads(
             (state_dir / "evolve_queue.jsonl").read_text().strip())
-        assert entry["dry"] is True
+        assert "dry" not in entry
         assert entry["status"] == "pending"
 
     def test_non_dry_run_omits_dry_flag(self, evolve_env):

--- a/tests/test_evolve_queue.py
+++ b/tests/test_evolve_queue.py
@@ -106,3 +106,13 @@ def test_old_pr_created_does_not_block(monkeypatch, tmp_path):
         json.dumps({"ts": time.time() - 90000, "id": "old", "status": "pr_created"}) + "\n")
     entry = eq.enqueue_evolve("allowed", "obi", "obi-chat")
     assert entry["status"] == "pending"
+
+
+def test_enqueue_raises_if_filelock_unavailable(monkeypatch, tmp_path):
+    # filelock is a hard dependency — if it's somehow missing, writes must fail loudly
+    # rather than running unlocked (TOCTOU on concurrent enqueues)
+    eq = _setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(eq, "_FileLock", None)
+    with pytest.raises(RuntimeError, match="filelock"):
+        eq.enqueue_evolve("some intent", "obi", "obi-chat")
+    assert not (tmp_path / "evolve_queue.jsonl").exists()

--- a/tests/test_evolve_queue.py
+++ b/tests/test_evolve_queue.py
@@ -1,0 +1,108 @@
+# tests/test_evolve_queue.py
+import json, time
+import pytest
+
+
+def _setup(monkeypatch, tmp_path):
+    monkeypatch.setenv("PX_STATE_DIR", str(tmp_path))
+    import importlib, pxh.evolve_queue as eq
+    importlib.reload(eq)
+    return eq
+
+
+def test_enqueue_writes_full_schema(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "introspection.json").write_text('{"battery": 90}')
+    entry = eq.enqueue_evolve("add a joke tool", "obi", "obi-chat")
+    assert entry["status"] == "pending"
+    assert entry["requester"] == "obi" and entry["source"] == "obi-chat"
+    assert entry["introspection"] == {"battery": 90}
+    assert entry["intent"] == "add a joke tool"
+    assert entry["id"].startswith("evolve-")
+    line = (tmp_path / "evolve_queue.jsonl").read_text().strip()
+    assert json.loads(line)["status"] == "pending"
+
+
+def test_enqueue_defaults_introspection_to_empty(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    entry = eq.enqueue_evolve("x feature", "obi", "obi-chat")
+    assert entry["introspection"] == {}
+
+
+def test_enqueue_rejects_empty_and_oversized(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    with pytest.raises(ValueError):
+        eq.enqueue_evolve("   ", "obi", "obi-chat")
+    with pytest.raises(ValueError):
+        eq.enqueue_evolve("z" * 301, "obi", "obi-chat")
+
+
+def test_enqueue_sanitizes_intent(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    entry = eq.enqueue_evolve("make <b>jokes</b>\nnow\x00", "obi", "obi-chat")
+    assert "<" not in entry["intent"] and "\n" not in entry["intent"] and "\x00" not in entry["intent"]
+
+
+def test_one_pending_per_requester(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    eq.enqueue_evolve("first feature request", "obi", "obi-chat")
+    with pytest.raises(eq.EvolvePendingError):
+        eq.enqueue_evolve("second feature request", "obi", "obi-chat")
+    # different requester is unaffected
+    eq.enqueue_evolve("adrians own request", "adrian", "cli")
+
+
+def test_building_status_blocks_new_enqueue(monkeypatch, tmp_path):
+    # a project mid-build must block a second enqueue (quota-bypass guard)
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "evolve_queue.jsonl").write_text(
+        json.dumps({"id": "x", "intent": "in progress", "status": "building",
+                    "requester": "obi"}) + "\n")
+    with pytest.raises(eq.EvolvePendingError):
+        eq.enqueue_evolve("another while building", "obi", "obi-chat")
+
+
+def test_rate_limited_accepts_iso_ts_completed(monkeypatch, tmp_path):
+    # older log entries use ISO ts_completed, not numeric ts — must still count
+    eq = _setup(monkeypatch, tmp_path)
+    from datetime import datetime, timezone
+    iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (tmp_path / "evolve_log.jsonl").write_text(
+        json.dumps({"id": "old", "status": "pr_created", "ts_completed": iso}) + "\n")
+    with pytest.raises(eq.EvolveQuotaError):
+        eq.enqueue_evolve("blocked by iso entry", "obi", "obi-chat")
+
+
+def test_build_pr_body_flags_requester(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    body = eq.build_pr_body("add joke tool", ["bin/tool-joke"], "obi", "obi-chat")
+    assert "Requested by" in body and "obi" in body and "adversarial" in body.lower()
+    assert "bin/tool-joke" in body
+
+
+def test_reset_building_to_pending(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "evolve_queue.jsonl").write_text("\n".join([
+        json.dumps({"id": "a", "status": "building", "requester": "obi"}),
+        json.dumps({"id": "b", "status": "pending", "requester": "obi"}),
+        json.dumps({"id": "c", "status": "pr_created", "requester": "adrian"}),
+    ]) + "\n")
+    assert eq.reset_building_to_pending() == 1
+    statuses = {e["id"]: e["status"] for e in eq.read_queue()}
+    assert statuses == {"a": "pending", "b": "pending", "c": "pr_created"}
+
+
+def test_rate_limited_by_recent_pr_created(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "evolve_log.jsonl").write_text(
+        json.dumps({"ts": time.time(), "id": "evolve-x", "status": "pr_created"}) + "\n")
+    with pytest.raises(eq.EvolveQuotaError):
+        eq.enqueue_evolve("blocked", "obi", "obi-chat")
+
+
+def test_old_pr_created_does_not_block(monkeypatch, tmp_path):
+    eq = _setup(monkeypatch, tmp_path)
+    (tmp_path / "evolve_log.jsonl").write_text(
+        json.dumps({"ts": time.time() - 90000, "id": "old", "status": "pr_created"}) + "\n")
+    entry = eq.enqueue_evolve("allowed", "obi", "obi-chat")
+    assert entry["status"] == "pending"


### PR DESCRIPTION
## Conversational Self-Evolution (#162)

Lets Obi (authenticated obi-chat) and Adrian (CLI) ask SPARK to build a feature; SPARK confirms and enqueues an intent to the existing `px-evolve` pipeline, which produces a **human-approved PR** — with **no new code-execution surface**.

### What changed (7 TDD tasks, 10 commits)
- **T1** `src/pxh/evolve_queue.py` — single-writer `enqueue_evolve` (one schema, one rate-limit, one dedup, all inside one `FileLock`), `build_pr_body`, `reset_building_to_pending`, `entry_epoch`.
- **T2** `bin/tool-evolve` — routes through the shared writer (`requester="adrian"`, `source="cli"`). Intentionally drops the old 20-char/introspect-first CLI guards + per-entry `dry` field to match the conversational path.
- **T3** `bin/px-evolve` — marks `building` before processing, resets stale `building→pending` at startup (crash recovery), carries `requester`/`source` into the PR body + log.
- **T4** `src/pxh/api.py` — obi-chat emits structured JSON; robust `_parse_obi_reply` with raw_decode extraction, fallback, action clamp.
- **T5** `src/pxh/api.py` — **server-side confirm gate**: `propose` records `obi_evolve_pending.json` (no enqueue); `confirm` enqueues the **recorded** intent (never the model's confirm-turn value) only if a non-expired proposal exists **and** a deterministic `_is_affirmation(obi_text)` (with negation veto) passes on the sanitized user message.
- **T6** `GET /api/v1/obi/projects` (authed) — merge queue+log, `requester=="obi"` filter, state map, id-dedup (log wins), newest-first.
- **T7** dashboard "My Projects" panel (XSS-safe DOM) + obi-chat projects-status summary injected into the prompt.

### Security model (verified end-to-end by review)
- No unauthenticated path to a code change: obi-chat is auth-gated; the conversation LLM keeps `--allowedTools ""` (no file/shell tools). The only effect of any conversation is a `status:"pending"` queue row a human reviews before any PR.
- Injection-safe: the enqueued intent is the server-recorded proposal, gated server-side on the sanitized **user** message — not the model's self-classification. A test proves an injected `rm -rf` intent is discarded in favor of the recorded one.
- Dual rate-limit (24h `pr_created` window **and** one-active-per-requester incl. `building`) closes the mid-build quota bypass.

### Tests
Full suite **792 passed, 27 skipped**. Every task built test-first (RED→GREEN). New coverage in `tests/test_evolve_queue.py`, `tests/test_evolve.py`, `tests/test_evolve_coverage.py`, `tests/test_api.py`.

### Review
Executed via subagent-driven development: a fresh implementer + per-task spec/quality review for each task, plus a final opus whole-branch review — **Ready to merge: Yes**, no Critical/Important findings; all Minors triaged acceptable-to-ship.

Design: `docs/superpowers/specs/2026-06-21-conversational-self-evolution-design.md`
Plan: `docs/superpowers/plans/2026-06-21-conversational-self-evolution.md`

Closes #162
